### PR TITLE
Small changes

### DIFF
--- a/TestingLowerBounds/FDiv/Basic.lean
+++ b/TestingLowerBounds/FDiv/Basic.lean
@@ -775,15 +775,15 @@ lemma fDiv_restrict_of_integrable (μ ν : Measure α) [IsFiniteMeasure μ] [IsF
 section Measurability
 
 lemma measurableSet_integrable_f_kernel_rnDeriv [MeasurableSpace.CountablyGenerated β]
-    (κ η : kernel α β) [IsFiniteKernel κ] [IsFiniteKernel η] (hf : StronglyMeasurable f) :
-    MeasurableSet {a | Integrable (fun x ↦ f (kernel.rnDeriv κ η a x).toReal) (η a)} :=
+    (κ η ξ : kernel α β) [IsFiniteKernel ξ] (hf : StronglyMeasurable f) :
+    MeasurableSet {a | Integrable (fun x ↦ f (kernel.rnDeriv κ η a x).toReal) (ξ a)} :=
   measurableSet_kernel_integrable
     (hf.comp_measurable (kernel.measurable_rnDeriv κ η).ennreal_toReal)
 
 lemma measurableSet_integrable_f_rnDeriv [MeasurableSpace.CountablyGenerated β]
     (κ η : kernel α β) [IsFiniteKernel κ] [IsFiniteKernel η] (hf : StronglyMeasurable f) :
     MeasurableSet {a | Integrable (fun x ↦ f ((∂κ a/∂η a) x).toReal) (η a)} := by
-  convert measurableSet_integrable_f_kernel_rnDeriv κ η hf using 3 with a
+  convert measurableSet_integrable_f_kernel_rnDeriv κ η η hf using 3 with a
   refine integrable_congr ?_
   filter_upwards [kernel.rnDeriv_eq_rnDeriv_measure κ η a] with b hb
   rw [hb]

--- a/TestingLowerBounds/ForMathlib/EReal.lean
+++ b/TestingLowerBounds/ForMathlib/EReal.lean
@@ -7,6 +7,8 @@ open scoped ENNReal NNReal
 
 namespace EReal
 
+instance : CharZero EReal := inferInstanceAs (CharZero (WithBot (WithTop ℝ)))
+
 lemma coe_ennreal_toReal {x : ℝ≥0∞} (hx : x ≠ ∞) : (x.toReal : EReal) = x := by
   lift x to ℝ≥0 using hx
   rfl

--- a/TestingLowerBounds/MeasureCompProd.lean
+++ b/TestingLowerBounds/MeasureCompProd.lean
@@ -124,19 +124,19 @@ variable {E : Type*}
 
 -- todo find better name
 theorem _root_.MeasureTheory.Integrable.compProd_mk_left_ae' [NormedAddCommGroup E]
-    [IsFiniteMeasure μ] [IsSFiniteKernel κ] ⦃f : α × β → E⦄
+    [SFinite μ] [IsSFiniteKernel κ] ⦃f : α × β → E⦄
     (hf : Integrable f (μ ⊗ₘ κ)) :
     ∀ᵐ x ∂μ, Integrable (fun y ↦ f (x, y)) (κ x) :=
   hf.compProd_mk_left_ae
 
 theorem _root_.MeasureTheory.Integrable.integral_norm_compProd' [NormedAddCommGroup E]
-    [IsFiniteMeasure μ] [IsSFiniteKernel κ] ⦃f : α × β → E⦄
+    [SFinite μ] [IsSFiniteKernel κ] ⦃f : α × β → E⦄
     (hf : Integrable f (μ ⊗ₘ κ)) :
     Integrable (fun x ↦ ∫ y, ‖f (x, y)‖ ∂(κ x)) μ :=
   hf.integral_norm_compProd
 
 theorem _root_.MeasureTheory.Integrable.integral_compProd' [NormedAddCommGroup E]
-    [IsFiniteMeasure μ] [IsSFiniteKernel κ] ⦃f : α × β → E⦄ [NormedSpace ℝ E] [CompleteSpace E]
+    [SFinite μ] [IsSFiniteKernel κ] ⦃f : α × β → E⦄ [NormedSpace ℝ E] [CompleteSpace E]
     (hf : Integrable f (μ ⊗ₘ κ)) :
     Integrable (fun x ↦ ∫ y, f (x, y) ∂(κ x)) μ :=
   hf.integral_compProd


### PR DESCRIPTION
Generalize measurableSet_integrable_f_kernel_rnDeriv to allow the kernel with respect to which we have the integrability to be an arbitrary one.
Add instance CharZero EReal.
Generalize some lemmas from finite measures to S finite ones.