### PR TITLE
feat: condFDiv_compProd_meas

### DIFF
--- a/TestingLowerBounds/FDiv/CondFDiv.lean
+++ b/TestingLowerBounds/FDiv/CondFDiv.lean
@@ -768,8 +768,7 @@ lemma condFDiv_kernel_snd'_integrable_iff [CountablyGenerated γ] [IsFiniteMeasu
     exact (integrable_fDiv_iff ha_int ha_ae).mpr ha_int2
   rw [integrable_congr <| condFDiv_snd'_toReal_eq_ae h_ac h_int h_int2]
   refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
-  ·
-    --using `h_le` we reduce the problem to the integrability of a sum of an integral and `f'(∞) * (ξ x) (univ)`
+  · --using `h_le` we reduce the problem to the integrability of a sum of an integral and `f'(∞) * (ξ x) (univ)`
     apply Integrable.mono'
       (g := fun a ↦ ∫ b, ((fDiv f (κ (a, b)) (η (a, b))).toReal + |(derivAtTop f).toReal|) ∂ξ a)
     rotate_left
@@ -785,12 +784,10 @@ lemma condFDiv_kernel_snd'_integrable_iff [CountablyGenerated γ] [IsFiniteMeasu
     swap
     · filter_upwards [h_int2'] with a ha_int2'
       rw [integral_add ha_int2' (integrable_const _), integral_const, smul_eq_mul]
-
     --we already know the integrability of the integral (hp `h`) and the other part is just a
     --constant times a finite kernel applied to a fixed set, so it's easy to show that it's integrable
     exact h.add (Integrable.kernel _ MeasurableSet.univ |>.mul_const _)
-  ·
-    --using `h_le'` we reduce the problem to the integrability of a sum of an integral and `f'(∞) * (ξ x) (univ)`
+  · --using `h_le'` we reduce the problem to the integrability of a sum of an integral and `f'(∞) * (ξ x) (univ)`
     apply Integrable.mono' (g := fun a ↦ ∫ b,
       (|∫ (x : γ), f ((∂κ (a, b)/∂η (a, b)) x).toReal ∂η (a, b)| + |(derivAtTop f).toReal|) ∂ξ a)
     rotate_left
@@ -806,7 +803,6 @@ lemma condFDiv_kernel_snd'_integrable_iff [CountablyGenerated γ] [IsFiniteMeasu
     swap
     · filter_upwards [h_int2] with a ha_int2
       rw [integral_add ha_int2.abs (integrable_const _), integral_const, smul_eq_mul]
-
     -- same as above
     exact h.add (Integrable.kernel _ MeasurableSet.univ |>.mul_const _)
 

--- a/TestingLowerBounds/FDiv/CondFDiv.lean
+++ b/TestingLowerBounds/FDiv/CondFDiv.lean
@@ -458,7 +458,7 @@ lemma condFDiv_zero_left [IsFiniteMeasure μ] [IsFiniteKernel η] :
     apply MeasureTheory.Integrable.const_mul
     exact kernel.IsFiniteKernel.integrable μ η MeasurableSet.univ
 
-@[simp]
+@[simp 1100]
 lemma condFDiv_zero_left' [IsProbabilityMeasure μ] [IsMarkovKernel η] :
     condFDiv f 0 η μ = f 0 := by
   simp_rw [condFDiv_zero_left, measure_univ, integral_const, measure_univ]

--- a/TestingLowerBounds/FDiv/CondFDiv.lean
+++ b/TestingLowerBounds/FDiv/CondFDiv.lean
@@ -709,7 +709,8 @@ lemma fDiv_toReal_eq_ae {ξ : kernel α β} {κ η : kernel (α × β) γ} [IsFi
       + (derivAtTop f).toReal * (((κ (a, b)).singularPart (η (a, b)) Set.univ)).toReal := by
   filter_upwards [eventually_all.mpr h_ac, h_int] with a ha_ae ha_int
   filter_upwards [eventually_all.mpr ha_ae, ha_int] with b hb_ae hb_int
-  rw [← EReal.toReal_coe (∫ _, _ ∂_), fDiv_of_integrable hb_int, ← EReal.toReal_coe_ennreal, ← EReal.toReal_mul]
+  rw [← EReal.toReal_coe (∫ _, _ ∂_), fDiv_of_integrable hb_int, ← EReal.toReal_coe_ennreal,
+    ← EReal.toReal_mul]
   refine EReal.toReal_add ?_ ?_ ?_ ?_
   · simp only [ne_eq, EReal.coe_ne_top, not_false_eq_true]
   · simp only [ne_eq, EReal.coe_ne_bot, not_false_eq_true]
@@ -768,7 +769,8 @@ lemma condFDiv_kernel_snd'_integrable_iff [CountablyGenerated γ] [IsFiniteMeasu
           + (derivAtTop f).toReal * (((κ (a, b)).singularPart (η (a, b)) Set.univ)).toReal| := by
         rw [hb_ereal_add]
       _ ≤ |∫ x, f ((∂κ (a, b)/∂η (a, b)) x).toReal ∂η (a, b)|
-          + |(derivAtTop f).toReal * (((κ (a, b)).singularPart (η (a, b)) Set.univ)).toReal| := abs_add _ _
+          + |(derivAtTop f).toReal * (((κ (a, b)).singularPart (η (a, b)) Set.univ)).toReal| :=
+        abs_add _ _
       _ ≤ |∫ x, f ((∂κ (a, b)/∂η (a, b)) x).toReal ∂η (a, b)|
           + |(derivAtTop f).toReal| * ((κ (a, b)) Set.univ).toReal := by
         gcongr

--- a/TestingLowerBounds/FDiv/CondFDiv.lean
+++ b/TestingLowerBounds/FDiv/CondFDiv.lean
@@ -867,7 +867,7 @@ lemma condFDiv_compProd_meas_eq_top [CountablyGenerated γ] [IsFiniteMeasure μ]
         h_int, eventually_all, false_and, not_false_eq_true, true_or, implies_true]
     have h_int' := h_int
     rw [← Measure.ae_compProd_iff (measurableSet_integrable_f_rnDeriv κ η hf_meas)] at h_int'
-    rw [← not_imp]
+    rw [← _root_.not_imp]
     simp_all only [forall_true_left, not_true_eq_false, implies_true, or_false, false_or, ne_eq,
       not_eventually, not_not]
     rw [Measure.integrable_compProd_iff

--- a/TestingLowerBounds/FDiv/CondFDiv.lean
+++ b/TestingLowerBounds/FDiv/CondFDiv.lean
@@ -458,11 +458,9 @@ lemma condFDiv_zero_left [IsFiniteMeasure μ] [IsFiniteKernel η] :
     apply MeasureTheory.Integrable.const_mul
     exact kernel.IsFiniteKernel.integrable μ η MeasurableSet.univ
 
-@[simp 1100]
 lemma condFDiv_zero_left' [IsProbabilityMeasure μ] [IsMarkovKernel η] :
     condFDiv f 0 η μ = f 0 := by
-  simp_rw [condFDiv_zero_left, measure_univ, integral_const, measure_univ]
-  norm_num
+  simp
 
 --I also wanted to add something like condKL_zero_right, but it turns out it's not so
 --straightforward to state and prove, and since we don't really need it for now I will leave it out.

--- a/TestingLowerBounds/FDiv/CondFDiv.lean
+++ b/TestingLowerBounds/FDiv/CondFDiv.lean
@@ -740,50 +740,23 @@ lemma condFDiv_kernel_snd'_integrable_iff [CountablyGenerated γ] [IsFiniteMeasu
     (hf_cont : ContinuousOn f (Set.Ici 0)) (hf_one : f 1 = 0) :
     Integrable (fun a ↦ (condFDiv f (kernel.snd' κ a) (kernel.snd' η a) (ξ a)).toReal) μ ↔
       Integrable (fun a ↦ ∫ b, |∫ x, f ((∂κ (a, b)/∂η (a, b)) x).toReal ∂η (a, b)| ∂ξ a) μ := by
-  have h_le : ∀ᵐ a ∂μ, ∀ᵐ b ∂ξ a, |∫ (x : γ), f ((∂κ (a, b)/∂η (a, b)) x).toReal ∂η (a, b)|
-      ≤ (fDiv f (κ (a, b)) (η (a, b))).toReal + |(derivAtTop f).toReal| := by
+  have h_le : ∀ᵐ a ∂μ, ∀ᵐ b ∂ξ a, |∫ x, f ((∂κ (a, b)/∂η (a, b)) x).toReal ∂η (a, b)|
+        - (fDiv f (κ (a, b)) (η (a, b))).toReal ≤ |(derivAtTop f).toReal|
+      ∧ (fDiv f (κ (a, b)) (η (a, b))).toReal - |∫ x, f ((∂κ (a, b)/∂η (a, b)) x).toReal ∂η (a, b)|
+        ≤ |(derivAtTop f).toReal| := by
     filter_upwards [fDiv_toReal_eq_ae h_ac h_int] with a ha_ereal_add
     filter_upwards [ha_ereal_add] with b hb_ereal_add
+    apply abs_sub_le_iff.mp
     calc
-      _ = |∫ (x : γ), f ((∂κ (a, b)/∂η (a, b)) x).toReal ∂η (a, b)
-          + (derivAtTop f).toReal * ((κ (a, b)).singularPart (η (a, b)) Set.univ).toReal
-          - (derivAtTop f).toReal * ((κ (a, b)).singularPart (η (a, b)) Set.univ).toReal| := by
-        ring_nf
+      _ = |(|∫ (x : γ), f ((∂κ (a, b)/∂η (a, b)) x).toReal ∂η (a, b)|
+          - |(fDiv f (κ (a, b)) (η (a, b))).toReal|)| := by
+        rw [abs_eq_self.mpr <| EReal.toReal_nonneg (fDiv_nonneg hf_cvx hf_cont hf_one)]
       _ ≤ |∫ (x : γ), f ((∂κ (a, b)/∂η (a, b)) x).toReal ∂η (a, b)
-          + (derivAtTop f).toReal * ((κ (a, b)).singularPart (η (a, b)) Set.univ).toReal|
-          + |(derivAtTop f).toReal * ((κ (a, b)).singularPart (η (a, b)) Set.univ).toReal| :=
-        abs_sub _ _
-      _ = |(fDiv f (κ (a, b)) (η (a, b))).toReal|
-          + |(derivAtTop f).toReal * ((κ (a, b)).singularPart (η (a, b)) Set.univ).toReal| := by
-        congr
-        exact hb_ereal_add.symm
-      _ ≤ (fDiv f (κ (a, b)) (η (a, b))).toReal
-          + |(derivAtTop f).toReal| * ((κ (a, b)) Set.univ).toReal := by
-        gcongr ?_ + ?_
-        · rw [abs_eq_self.mpr <| EReal.toReal_nonneg (fDiv_nonneg hf_cvx hf_cont hf_one)]
-        · rw [abs_mul, ENNReal.abs_toReal]
-          apply mul_le_mul_of_nonneg_left _ (abs_nonneg _)
-          gcongr
-          · exact measure_ne_top (κ (a, b)) Set.univ
-          · exact Measure.singularPart_le (κ (a, b)) (η (a, b)) Set.univ
-      _ = _ := by rw [measure_univ, ENNReal.one_toReal, mul_one]
-  have h_le' : ∀ᵐ a ∂μ, ∀ᵐ b ∂ξ a, (fDiv f (κ (a, b)) (η (a, b))).toReal
-      ≤ |∫ (x : γ), f ((∂κ (a, b)/∂η (a, b)) x).toReal ∂η (a, b)| + |(derivAtTop f).toReal| := by
-    filter_upwards [fDiv_toReal_eq_ae h_ac h_int] with a ha_ereal_add
-    filter_upwards [ha_ereal_add] with b hb_ereal_add
-    calc
-      _ = |(fDiv f (κ (a, b)) (η (a, b))).toReal| :=
-        (abs_eq_self.mpr <| EReal.toReal_nonneg <| fDiv_nonneg hf_cvx hf_cont hf_one).symm
-      _ = |∫ x, f ((∂κ (a, b)/∂η (a, b)) x).toReal ∂η (a, b)
-          + (derivAtTop f).toReal * (((κ (a, b)).singularPart (η (a, b)) Set.univ)).toReal| := by
-        rw [hb_ereal_add]
-      _ ≤ |∫ x, f ((∂κ (a, b)/∂η (a, b)) x).toReal ∂η (a, b)|
-          + |(derivAtTop f).toReal * (((κ (a, b)).singularPart (η (a, b)) Set.univ)).toReal| :=
-        abs_add _ _
-      _ ≤ |∫ x, f ((∂κ (a, b)/∂η (a, b)) x).toReal ∂η (a, b)|
-          + |(derivAtTop f).toReal| * ((κ (a, b)) Set.univ).toReal := by
-        gcongr
-        rw [abs_mul, ENNReal.abs_toReal]
+          - (fDiv f (κ (a, b)) (η (a, b))).toReal| := by
+        exact abs_abs_sub_abs_le_abs_sub _ _
+      _ = |(derivAtTop f).toReal| * ((κ (a, b)).singularPart (η (a, b)) Set.univ).toReal := by
+        rw [hb_ereal_add, sub_add_cancel_left, abs_neg, abs_mul, ENNReal.abs_toReal]
+      _ ≤ |(derivAtTop f).toReal| * ((κ (a, b)) Set.univ).toReal := by
         apply mul_le_mul_of_nonneg_left _ (abs_nonneg _)
         gcongr
         · exact measure_ne_top (κ (a, b)) Set.univ
@@ -805,7 +778,8 @@ lemma condFDiv_kernel_snd'_integrable_iff [CountablyGenerated γ] [IsFiniteMeasu
       exact measurable_integral_f_rnDeriv κ η hf_meas
     · filter_upwards [h_le, h_int2, h_int2'] with a ha_le ha_int2 ha_int2'
       rw [norm_eq_abs, abs_eq_self.mpr <| integral_nonneg <| fun _ ↦ abs_nonneg _]
-      exact integral_mono_ae ha_int2.abs (integrable_add_const_iff.mpr ha_int2') ha_le
+      refine integral_mono_ae ha_int2.abs (integrable_add_const_iff.mpr ha_int2') ?_
+      filter_upwards [ha_le] with a hb_le using by linarith
     apply Integrable.congr (f := fun a ↦ ∫ b, (fDiv f (κ (a, b)) (η (a, b))).toReal ∂ξ a
         + ((ξ a) Set.univ).toReal * |(derivAtTop f).toReal|)
     swap
@@ -822,10 +796,11 @@ lemma condFDiv_kernel_snd'_integrable_iff [CountablyGenerated γ] [IsFiniteMeasu
     rotate_left
     · refine (StronglyMeasurable.integral_kernel_prod_right ?_).aestronglyMeasurable
       exact (measurable_fDiv _ _ hf_meas).ereal_toReal.stronglyMeasurable
-    · filter_upwards [h_le', h_int2, h_int2'] with a ha_le ha_int2 ha_int2'
+    · filter_upwards [h_le, h_int2, h_int2'] with a ha_le ha_int2 ha_int2'
       rw [norm_eq_abs, abs_eq_self.mpr <| integral_nonneg <| fun _ ↦ EReal.toReal_nonneg <|
         fDiv_nonneg hf_cvx hf_cont hf_one]
-      apply integral_mono_ae ha_int2' (integrable_add_const_iff.mpr <| ha_int2.abs) ha_le
+      refine integral_mono_ae ha_int2' (integrable_add_const_iff.mpr <| ha_int2.abs) ?_
+      filter_upwards [ha_le] with a hb_le using by linarith
     apply Integrable.congr (f := fun a ↦ ∫ b, |∫ x, f ((∂κ (a, b)/∂η (a, b)) x).toReal ∂η (a, b)|
       ∂ξ a + ((ξ a) Set.univ).toReal * |(derivAtTop f).toReal|)
     swap


### PR DESCRIPTION
Add `condFDiv_compProd_meas`, adapting the proof from the analogous lemma for KL.
Add the auxiliary lemmas `condFDiv_compProd_meas_eq_top`, `condFDiv_kernel_fst'_integrable_iff`, `condFDiv_kernel_snd'_integrable_iff`.

Depends on #34.