### PR TITLE
Generalize lemmas about `fDiv`

### DIFF
--- a/TestingLowerBounds/FDiv/Basic.lean
+++ b/TestingLowerBounds/FDiv/Basic.lean
@@ -413,8 +413,7 @@ lemma fDiv_eq_add_withDensity_derivAtTop
     derivAtTop_sub_const hf_cvx]
   simp
 
-lemma fDiv_lt_top_of_ac [SigmaFinite μ] [SigmaFinite ν] (h : μ ≪ ν)
-    (h_int : Integrable (fun x ↦ f ((∂μ/∂ν) x).toReal) ν) :
+lemma fDiv_lt_top_of_ac (h : μ ≪ ν) (h_int : Integrable (fun x ↦ f ((∂μ/∂ν) x).toReal) ν) :
     fDiv f μ ν < ⊤ := by
   classical
   rw [fDiv_of_absolutelyContinuous h, if_pos h_int]
@@ -604,37 +603,30 @@ lemma fDiv_of_derivAtTop_eq_top [SigmaFinite μ] [SigmaFinite ν] (hf : derivAtT
 
 end derivAtTopTop
 
-lemma fDiv_lt_top_of_derivAtTop_ne_top [IsFiniteMeasure μ] [SigmaFinite ν]
-    (hf : derivAtTop f ≠ ⊤) (h_int : Integrable (fun x ↦ f ((∂μ/∂ν) x).toReal) ν) :
+lemma fDiv_lt_top_of_derivAtTop_ne_top [IsFiniteMeasure μ] (hf : derivAtTop f ≠ ⊤)
+    (h_int : Integrable (fun x ↦ f ((∂μ/∂ν) x).toReal) ν) :
     fDiv f μ ν < ⊤ := by
   rw [fDiv_of_integrable h_int]
   refine EReal.add_lt_top ?_ ?_
   · simp
-  · have : μ.singularPart ν Set.univ < (⊤ : EReal) := by
-      rw [← EReal.coe_ennreal_top]
-      norm_cast
-      exact measure_lt_top _ _
-    rw [ne_eq, EReal.mul_eq_top]
+  · rw [ne_eq, EReal.mul_eq_top]
     simp only [derivAtTop_ne_bot, false_and, EReal.coe_ennreal_ne_bot, and_false, hf,
       EReal.coe_ennreal_pos, Measure.measure_univ_pos, ne_eq, EReal.coe_ennreal_eq_top_iff,
       false_or, not_and]
     exact fun _ ↦ measure_ne_top _ _
 
-lemma fDiv_lt_top_iff_of_derivAtTop_ne_top [IsFiniteMeasure μ] [SigmaFinite ν]
-    (hf : derivAtTop f ≠ ⊤) :
+lemma fDiv_lt_top_iff_of_derivAtTop_ne_top [IsFiniteMeasure μ] (hf : derivAtTop f ≠ ⊤) :
     fDiv f μ ν < ⊤ ↔ Integrable (fun x ↦ f ((∂μ/∂ν) x).toReal) ν := by
   refine ⟨fun h ↦ ?_, fDiv_lt_top_of_derivAtTop_ne_top hf⟩
   by_contra h_not_int
   rw [fDiv_of_not_integrable h_not_int] at h
   simp at h
 
-lemma fDiv_ne_top_iff_of_derivAtTop_ne_top [IsFiniteMeasure μ] [SigmaFinite ν]
-    (hf : derivAtTop f ≠ ⊤) :
+lemma fDiv_ne_top_iff_of_derivAtTop_ne_top [IsFiniteMeasure μ] (hf : derivAtTop f ≠ ⊤) :
     fDiv f μ ν ≠ ⊤ ↔ Integrable (fun x ↦ f ((∂μ/∂ν) x).toReal) ν := by
   rw [← fDiv_lt_top_iff_of_derivAtTop_ne_top hf, lt_top_iff_ne_top]
 
-lemma fDiv_eq_top_iff_of_derivAtTop_ne_top [IsFiniteMeasure μ] [SigmaFinite ν]
-    (hf : derivAtTop f ≠ ⊤) :
+lemma fDiv_eq_top_iff_of_derivAtTop_ne_top [IsFiniteMeasure μ] (hf : derivAtTop f ≠ ⊤) :
     fDiv f μ ν = ⊤ ↔ ¬ Integrable (fun x ↦ f ((∂μ/∂ν) x).toReal) ν := by
   rw [← fDiv_ne_top_iff_of_derivAtTop_ne_top hf, not_not]
 
@@ -667,7 +659,7 @@ lemma fDiv_of_ne_top (h : fDiv f μ ν ≠ ⊤) :
   rw [fDiv_of_integrable]
   exact integrable_of_fDiv_ne_top h
 
-lemma toReal_fDiv_of_integrable [IsFiniteMeasure μ] [IsFiniteMeasure ν]
+lemma toReal_fDiv_of_integrable [IsFiniteMeasure μ]
     (hf_int : Integrable (fun x ↦ f ((∂μ/∂ν) x).toReal) ν)
     (h_deriv : derivAtTop f = ⊤ → μ ≪ ν) :
     (fDiv f μ ν).toReal = ∫ y, f ((∂μ/∂ν) y).toReal ∂ν

--- a/TestingLowerBounds/FDiv/CondFDiv.lean
+++ b/TestingLowerBounds/FDiv/CondFDiv.lean
@@ -530,7 +530,7 @@ and in `condFDiv f κ η μ` are equivalent. -/
 variable [CountablyGenerated β]
 
 lemma fDiv_compProd_ne_top_iff [IsFiniteMeasure μ] [IsFiniteMeasure ν]
-    [IsMarkovKernel κ] [IsFiniteKernel η] (hf : StronglyMeasurable f)
+    [IsFiniteKernel κ] [∀ a, NeZero (κ a)] [IsFiniteKernel η] (hf : StronglyMeasurable f)
     (h_cvx : ConvexOn ℝ (Set.Ici 0) f) :
     fDiv f (μ ⊗ₘ κ) (ν ⊗ₘ η) ≠ ⊤ ↔
       (∀ᵐ a ∂ν, Integrable (fun x ↦ f ((∂μ/∂ν) a * (∂κ a/∂η a) x).toReal) (η a))
@@ -540,7 +540,7 @@ lemma fDiv_compProd_ne_top_iff [IsFiniteMeasure μ] [IsFiniteMeasure ν]
     kernel.Measure.absolutelyContinuous_compProd_iff, and_assoc]
 
 lemma fDiv_compProd_eq_top_iff [IsFiniteMeasure μ] [IsFiniteMeasure ν]
-    [IsMarkovKernel κ] [IsFiniteKernel η] (hf : StronglyMeasurable f)
+    [IsFiniteKernel κ] [∀ a, NeZero (κ a)] [IsFiniteKernel η] (hf : StronglyMeasurable f)
     (h_cvx : ConvexOn ℝ (Set.Ici 0) f) :
     fDiv f (μ ⊗ₘ κ) (ν ⊗ₘ η) = ⊤ ↔
       (∀ᵐ a ∂ν, Integrable (fun x ↦ f ((∂μ/∂ν) a * (∂κ a/∂η a) x).toReal) (η a)) →
@@ -551,7 +551,7 @@ lemma fDiv_compProd_eq_top_iff [IsFiniteMeasure μ] [IsFiniteMeasure ν]
   rfl
 
 lemma fDiv_compProd_right_ne_top_iff [IsFiniteMeasure μ]
-    [IsMarkovKernel κ] [IsFiniteKernel η] (hf : StronglyMeasurable f)
+    [IsFiniteKernel κ] [∀ a, NeZero (κ a)] [IsFiniteKernel η] (hf : StronglyMeasurable f)
     (h_cvx : ConvexOn ℝ (Set.Ici 0) f) :
     fDiv f (μ ⊗ₘ κ) (μ ⊗ₘ η) ≠ ⊤ ↔
       (∀ᵐ a ∂μ, Integrable (fun x ↦ f ((∂κ a/∂η a) x).toReal) (η a))
@@ -578,7 +578,7 @@ lemma fDiv_compProd_right_ne_top_iff [IsFiniteMeasure μ]
     exact h.2.2
 
 lemma fDiv_compProd_right_eq_top_iff [IsFiniteMeasure μ]
-    [IsMarkovKernel κ] [IsFiniteKernel η] (hf : StronglyMeasurable f)
+    [IsFiniteKernel κ] [∀ a, NeZero (κ a)] [IsFiniteKernel η] (hf : StronglyMeasurable f)
     (h_cvx : ConvexOn ℝ (Set.Ici 0) f) :
     fDiv f (μ ⊗ₘ κ) (μ ⊗ₘ η) = ⊤ ↔
       (∀ᵐ a ∂μ, Integrable (fun x ↦ f ((∂κ a/∂η a) x).toReal) (η a)) →
@@ -603,7 +603,6 @@ lemma fDiv_compProd_left_ne_top_iff [IsFiniteMeasure μ] [IsFiniteMeasure ν]
   refine ⟨fun ⟨_, h2, h3⟩ ↦ ⟨?_, h3⟩, fun ⟨h1, h2⟩ ↦ ⟨?_, ?_, h2⟩⟩
   · refine (integrable_congr ?_).mpr h2
     refine ae_of_all _ (fun a ↦ ?_)
-    simp only
     simp [this]
   · refine ae_of_all _ (fun a ↦ ?_)
     have : (fun x ↦ f (((∂μ/∂ν) a).toReal * ((∂κ a/∂κ a) x).toReal))
@@ -611,9 +610,9 @@ lemma fDiv_compProd_left_ne_top_iff [IsFiniteMeasure μ] [IsFiniteMeasure ν]
       filter_upwards [h_one a] with b hb
       simp [hb]
     rw [integrable_congr this]
-    simp
-  · simp only [this, integral_const, measure_univ, ENNReal.one_toReal, smul_eq_mul, one_mul]
-    exact h1
+    exact integrable_const _
+  · simpa only [this, integral_const, measure_univ, ENNReal.one_toReal, smul_eq_mul, one_mul]
+
 
 lemma fDiv_compProd_left_eq_top_iff [IsFiniteMeasure μ] [IsFiniteMeasure ν]
     [IsMarkovKernel κ] (hf : StronglyMeasurable f) (h_cvx : ConvexOn ℝ (Set.Ici 0) f) :
@@ -624,20 +623,20 @@ lemma fDiv_compProd_left_eq_top_iff [IsFiniteMeasure μ] [IsFiniteMeasure ν]
   rfl
 
 lemma condFDiv_ne_top_iff_fDiv_compProd_ne_top [IsFiniteMeasure μ]
-    [IsMarkovKernel κ] [IsFiniteKernel η] (hf : StronglyMeasurable f)
+    [IsFiniteKernel κ] [∀ a, NeZero (κ a)] [IsFiniteKernel η] (hf : StronglyMeasurable f)
     (h_cvx : ConvexOn ℝ (Set.Ici 0) f) :
     condFDiv f κ η μ ≠ ⊤ ↔ fDiv f (μ ⊗ₘ κ) (μ ⊗ₘ η) ≠ ⊤ := by
   rw [condFDiv_ne_top_iff, fDiv_compProd_right_ne_top_iff hf h_cvx]
 
 lemma condFDiv_eq_top_iff_fDiv_compProd_eq_top [IsFiniteMeasure μ]
-    [IsMarkovKernel κ] [IsFiniteKernel η] (hf : StronglyMeasurable f)
+    [IsFiniteKernel κ] [∀ a, NeZero (κ a)] [IsFiniteKernel η] (hf : StronglyMeasurable f)
     (h_cvx : ConvexOn ℝ (Set.Ici 0) f) :
     condFDiv f κ η μ = ⊤ ↔ fDiv f (μ ⊗ₘ κ) (μ ⊗ₘ η) = ⊤ := by
   rw [← not_iff_not]
   exact condFDiv_ne_top_iff_fDiv_compProd_ne_top hf h_cvx
 
 lemma fDiv_compProd_left (μ : Measure α) [IsFiniteMeasure μ]
-    (κ η : kernel α β) [IsMarkovKernel κ] [IsFiniteKernel η] (hf : StronglyMeasurable f)
+    (κ η : kernel α β) [IsFiniteKernel κ] [∀ a, NeZero (κ a)] [IsFiniteKernel η] (hf : StronglyMeasurable f)
     (h_cvx : ConvexOn ℝ (Set.Ici 0) f) :
     fDiv f (μ ⊗ₘ κ) (μ ⊗ₘ η) = condFDiv f κ η μ := by
   by_cases hf_top : condFDiv f κ η μ = ⊤
@@ -1033,7 +1032,7 @@ lemma fDiv_snd_le [Nonempty α] [StandardBorelSpace α]
 
 lemma fDiv_comp_le_compProd [Nonempty α] [StandardBorelSpace α]
     (μ ν : Measure α) [IsFiniteMeasure μ] [IsFiniteMeasure ν]
-    (κ η : kernel α β) [IsMarkovKernel κ] [IsMarkovKernel η]
+    (κ η : kernel α β) [IsFiniteKernel κ] [IsFiniteKernel η]
     (hf : StronglyMeasurable f)
     (hf_cvx : ConvexOn ℝ (Set.Ici 0) f) (hf_cont : ContinuousOn f (Set.Ici 0)) :
     fDiv f (μ ∘ₘ κ) (ν ∘ₘ η) ≤ fDiv f (μ ⊗ₘ κ) (ν ⊗ₘ η) := by
@@ -1042,7 +1041,7 @@ lemma fDiv_comp_le_compProd [Nonempty α] [StandardBorelSpace α]
 
 lemma fDiv_comp_left_le [Nonempty α] [StandardBorelSpace α] [CountablyGenerated β]
     (μ : Measure α) [IsFiniteMeasure μ]
-    (κ η : kernel α β) [IsMarkovKernel κ] [IsMarkovKernel η]
+    (κ η : kernel α β) [IsFiniteKernel κ] [∀ a, NeZero (κ a)] [IsFiniteKernel η]
     (hf : StronglyMeasurable f)
     (hf_cvx : ConvexOn ℝ (Set.Ici 0) f) (hf_cont : ContinuousOn f (Set.Ici 0)) :
     fDiv f (μ ∘ₘ κ) (μ ∘ₘ η) ≤ condFDiv f κ η μ := by

--- a/TestingLowerBounds/ForMathlib/KernelFstSnd.lean
+++ b/TestingLowerBounds/ForMathlib/KernelFstSnd.lean
@@ -42,6 +42,9 @@ instance (κ : kernel (α × β) γ) (b : β) [IsFiniteKernel κ] : IsFiniteKern
 instance (κ : kernel (α × β) γ) (b : β) [IsSFiniteKernel κ] : IsSFiniteKernel (fst' κ b) := by
   rw [kernel.fst']; infer_instance
 
+instance (κ : kernel (α × β) γ) (a : α) (b : β) [NeZero (κ (a, b))] : NeZero ((fst' κ b) a) := by
+  rw [kernel.fst'_apply]; infer_instance
+
 instance (priority := 100) {κ : kernel (α × β) γ} [∀ b, IsMarkovKernel (fst' κ b)] :
     IsMarkovKernel κ := by
   refine ⟨fun _ ↦ ⟨?_⟩⟩
@@ -80,6 +83,9 @@ instance (κ : kernel (α × β) γ) (a : α) [IsFiniteKernel κ] : IsFiniteKern
 
 instance (κ : kernel (α × β) γ) (a : α) [IsSFiniteKernel κ] : IsSFiniteKernel (snd' κ a) := by
   rw [kernel.snd']; infer_instance
+
+instance (κ : kernel (α × β) γ) (a : α) (b : β) [NeZero (κ (a, b))] : NeZero ((snd' κ a) b) := by
+  rw [kernel.snd'_apply]; infer_instance
 
 instance (priority := 100) {κ : kernel (α × β) γ} [∀ b, IsMarkovKernel (snd' κ b)] :
     IsMarkovKernel κ := by

--- a/blueprint/src/sections/f_divergence.tex
+++ b/blueprint/src/sections/f_divergence.tex
@@ -431,7 +431,7 @@ TODO
   \lean{ProbabilityTheory.condFDiv_ne_top_iff_fDiv_compProd_ne_top}
   \leanok
   \uses{def:fDiv, def:condFDiv}
-  Let $\mu$ be a finite measure on $\mathcal X$ and let $\kappa, \eta : \mathcal X \rightsquigarrow \mathcal Y$ be two finite kernels, where $\kappa$ is a Markov kernel.
+  Let $\mu$ be a finite measure on $\mathcal X$ and let $\kappa, \eta : \mathcal X \rightsquigarrow \mathcal Y$ be two finite kernels, such that $\kappa (x) \neq 0 \; \forall x$.
   Then $D_f(\mu \otimes \kappa, \mu \otimes \eta) \ne \infty \iff D_f(\kappa, \eta \mid \mu) \ne \infty$.
 \end{lemma}
 
@@ -444,7 +444,7 @@ TODO
   \lean{ProbabilityTheory.fDiv_compProd_left}
   \leanok
   \uses{def:fDiv, def:condFDiv}
-  Let $\mu$ be a finite measure on $\mathcal X$ and let $\kappa, \eta : \mathcal X \rightsquigarrow \mathcal Y$ be two finite kernels.
+  Let $\mu$ be a finite measure on $\mathcal X$ and let $\kappa, \eta : \mathcal X \rightsquigarrow \mathcal Y$ be two finite kernels, such that $\kappa (x) \neq 0 \; \forall x$.
   Then $D_f(\mu \otimes \kappa, \mu \otimes \eta) = D_f(\kappa, \eta \mid \mu)$.
 \end{lemma}
 
@@ -572,7 +572,7 @@ Apply Lemma~\ref{thm:fDiv_compProd_right} with $\kappa$ the constant kernel with
   \lean{ProbabilityTheory.fDiv_comp_le_compProd}
   \leanok
   \uses{def:fDiv}
-  Let $\mu, \nu$ be two finite measures on a standard Borel space $\mathcal X$ and let $\kappa, \eta : \mathcal X \rightsquigarrow \mathcal Y$ be two Markov kernels.
+  Let $\mu, \nu$ be two finite measures on a standard Borel space $\mathcal X$ and let $\kappa, \eta : \mathcal X \rightsquigarrow \mathcal Y$ be two finite kernels.
   $D_f(\kappa \circ \mu, \eta \circ \nu) \le D_f(\mu \otimes \kappa, \nu \otimes \eta)$
 \end{lemma}
 
@@ -586,7 +586,7 @@ By definition, $\kappa \circ \mu$ is the marginal of $\mu \otimes \kappa$ (a mea
   \lean{ProbabilityTheory.fDiv_comp_left_le}
   \leanok
   \uses{def:fDiv, def:condFDiv}
-  Let $\mu$ be a measure on a standard Borel space $\mathcal X$ and let $\kappa, \eta : \mathcal X \rightsquigarrow \mathcal Y$ be two Markov kernels.
+  Let $\mu$ be a measure on a standard Borel space $\mathcal X$ and let $\kappa, \eta : \mathcal X \rightsquigarrow \mathcal Y$ be two finite kernels, such that $\kappa (x) \neq 0 \; \forall x$.
   Then $D_f(\kappa \circ \mu, \eta \circ \mu) \le D_f(\mu \otimes \kappa, \mu \otimes \eta) = D_f(\kappa, \eta \mid \mu)$
 \end{theorem}
 

--- a/blueprint/src/sections/f_divergence.tex
+++ b/blueprint/src/sections/f_divergence.tex
@@ -431,7 +431,7 @@ TODO
   \lean{ProbabilityTheory.condFDiv_ne_top_iff_fDiv_compProd_ne_top}
   \leanok
   \uses{def:fDiv, def:condFDiv}
-  Let $\mu$ be a finite measure on $\mathcal X$ and let $\kappa, \eta : \mathcal X \rightsquigarrow \mathcal Y$ be two finite kernels, such that $\kappa (x) \neq 0 \; \forall x$.
+  Let $\mu$ be a finite measure on $\mathcal X$ and let $\kappa, \eta : \mathcal X \rightsquigarrow \mathcal Y$ be two finite kernels, such that $\kappa(x) \ne 0$ for all $x$.
   Then $D_f(\mu \otimes \kappa, \mu \otimes \eta) \ne \infty \iff D_f(\kappa, \eta \mid \mu) \ne \infty$.
 \end{lemma}
 
@@ -444,7 +444,7 @@ TODO
   \lean{ProbabilityTheory.fDiv_compProd_left}
   \leanok
   \uses{def:fDiv, def:condFDiv}
-  Let $\mu$ be a finite measure on $\mathcal X$ and let $\kappa, \eta : \mathcal X \rightsquigarrow \mathcal Y$ be two finite kernels, such that $\kappa (x) \neq 0 \; \forall x$.
+  Let $\mu$ be a finite measure on $\mathcal X$ and let $\kappa, \eta : \mathcal X \rightsquigarrow \mathcal Y$ be two finite kernels, such that $\kappa(x) \ne 0$ for all $x$.
   Then $D_f(\mu \otimes \kappa, \mu \otimes \eta) = D_f(\kappa, \eta \mid \mu)$.
 \end{lemma}
 
@@ -586,7 +586,7 @@ By definition, $\kappa \circ \mu$ is the marginal of $\mu \otimes \kappa$ (a mea
   \lean{ProbabilityTheory.fDiv_comp_left_le}
   \leanok
   \uses{def:fDiv, def:condFDiv}
-  Let $\mu$ be a measure on a standard Borel space $\mathcal X$ and let $\kappa, \eta : \mathcal X \rightsquigarrow \mathcal Y$ be two finite kernels, such that $\kappa (x) \neq 0 \; \forall x$.
+  Let $\mu$ be a measure on a standard Borel space $\mathcal X$ and let $\kappa, \eta : \mathcal X \rightsquigarrow \mathcal Y$ be two finite kernels, such that $\kappa(x) \ne 0$ for all $x$.
   Then $D_f(\kappa \circ \mu, \eta \circ \mu) \le D_f(\mu \otimes \kappa, \mu \otimes \eta) = D_f(\kappa, \eta \mid \mu)$
 \end{theorem}
 


### PR DESCRIPTION
- Add instance of `NeZero` for `kernel.fst'` and `kernel.snd'`
- Remove unnecessary hp of sigma finiteness or finiteness from some lemmas in `fDiv.lean`
- Replace the hp `IsMarkovKernel κ` with `IsFiniteKernel κ`and `∀ a, NeZero (κ a)`where possible
- Fix blueprint accordingly
- Small cleanup