### PR TITLE
blueprint bug

### DIFF
--- a/blueprint/src/sections/hellinger_alpha.tex
+++ b/blueprint/src/sections/hellinger_alpha.tex
@@ -18,7 +18,7 @@
 \end{definition}
 
 \begin{lemma}
-  \label{lem:hellingerAlpha_ne_top_of_lt_one}
+  \label{lem:hellingerAlpha_ne_top_of_le_one}
   \lean{ProbabilityTheory.hellingerDiv_ne_top_of_le_one}
   \leanok
   \uses{def:hellingerAlpha}

--- a/blueprint/src/sections/hellinger_alpha.tex
+++ b/blueprint/src/sections/hellinger_alpha.tex
@@ -19,7 +19,7 @@
 
 \begin{lemma}
   \label{lem:hellingerAlpha_ne_top_of_lt_one}
-  \lean{ProbabilityTheory.hellingerDiv_ne_top_of_lt_one}
+  \lean{ProbabilityTheory.hellingerDiv_ne_top_of_le_one}
   \leanok
   \uses{def:hellingerAlpha}
   For $\alpha \in (0, 1)$ and finite measures $\mu, \nu$, $\He_\alpha(\mu, \nu) < \infty$.

--- a/blueprint/src/sections/renyi_divergence.tex
+++ b/blueprint/src/sections/renyi_divergence.tex
@@ -27,7 +27,7 @@
 \end{lemma}
 
 \begin{proof}\leanok
-\uses{lem:hellingerAlpha_ne_top_of_lt_one}
+\uses{lem:hellingerAlpha_ne_top_of_le_one}
 \end{proof}
 
 \begin{lemma}


### PR DESCRIPTION
Fix wrong name in blueprint, from `ProbabilityTheory.hellingerDiv_ne_top_of_lt_one` to `ProbabilityTheory.hellingerDiv_ne_top_of_le_one`