### PR TITLE
Refactor of Hellinger and Renyi divergences

### DIFF
--- a/TestingLowerBounds/Hellinger.lean
+++ b/TestingLowerBounds/Hellinger.lean
@@ -3,8 +3,6 @@ Copyright (c) 2024 Rémy Degenne. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Rémy Degenne, Lorenzo Luccioli
 -/
--- theorem foo (n : Nat) : 0 ≤ n := by exact? -- trick to make exact? work TODO : erase this when we are done
-
 import TestingLowerBounds.KullbackLeibler
 import Mathlib.Analysis.Convex.SpecificFunctions.Pow
 import Mathlib.Tactic.FunProp.Measurable
@@ -33,7 +31,6 @@ open Real MeasureTheory Filter
 open scoped ENNReal NNReal Topology
 
 namespace ProbabilityTheory
-
 
 --TODO: try to add these attributes to fun_prop? how to do this?
 attribute [fun_prop] Measure.measurable_rnDeriv Measurable.ennreal_toReal
@@ -105,9 +102,6 @@ lemma integrable_rpow_rnDeriv_iff [SigmaFinite ν] [SigmaFinite μ] (hμν : μ 
 
 section HellingerFun
 
--- noncomputable
--- def hellingerFun (a : ℝ) : ℝ → ℝ := fun x ↦ (a - 1)⁻¹ * (x ^ a - 1)
-
 /--Hellinger function, defined as `x ↦ (a - 1)⁻¹ * (x ^ a - 1)` for `a ∈ (0, 1) ∪ (1, + ∞)`.
 At `0` the function is obtained by contiuity and is the indicator function of `{0}`. At `1` it is
 defined as `x ↦ x * log x`, because in this way we obtain that the Hellinger divergence at `1`
@@ -124,19 +118,17 @@ lemma hellingerFun_zero : hellingerFun 0 = fun x ↦ if x = 0 then 1 else 0 := b
 
 lemma hellingerFun_zero' : hellingerFun 0 = fun x ↦ 0 ^ x := by
   ext x
-  by_cases h : x = 0
-    <;> simp [hellingerFun, h]
+  by_cases h : x = 0 <;> simp [hellingerFun, h]
 
 lemma hellingerFun_zero'' : hellingerFun 0 = Set.indicator {0} 1 := by
   ext x
-  by_cases h : x = 0
-    <;> simp [hellingerFun_zero, h]
+  by_cases h : x = 0 <;> simp [hellingerFun_zero, h]
 
 lemma hellingerFun_one : hellingerFun 1 = fun x ↦ x * log x := by
   ext x
   simp [hellingerFun]
 
-lemma hellingerFun_ne_zero_ne_one (ha_zero : a ≠ 0) (ha_one : a ≠ 1) :
+lemma hellingerFun_of_ne_zero_of_ne_one (ha_zero : a ≠ 0) (ha_one : a ≠ 1) :
     hellingerFun a = fun x ↦ (a - 1)⁻¹ * (x ^ a - 1) := by
   ext x
   simp [hellingerFun, ha_zero, ha_one]

--- a/TestingLowerBounds/Hellinger.lean
+++ b/TestingLowerBounds/Hellinger.lean
@@ -873,7 +873,7 @@ lemma condHellingerDiv_eq_integral'_of_one_lt (ha_ne_zero : a ≠ 0) (ha : 1 < a
       integral_sub (Integrable.const_mul h_int' _)
         (Integrable.const_mul (Integrable.kernel _ MeasurableSet.univ) _)
     _ = _ := by
-      rw [integral_mul_left, integral_mul_left, compProd_univ_toReal]
+      rw [integral_mul_left, integral_mul_left, Measure.compProd_univ_toReal]
 
 lemma condHellingerDiv_eq_integral'_of_one_lt' (ha_ne_zero : a ≠ 0) (ha : 1 < a) [IsFiniteMeasure μ]
     [IsFiniteKernel κ] [IsMarkovKernel η]
@@ -883,7 +883,8 @@ lemma condHellingerDiv_eq_integral'_of_one_lt' (ha_ne_zero : a ≠ 0) (ha : 1 < 
     condHellingerDiv a κ η μ = (a - 1)⁻¹ * ∫ x, ∫ b, ((∂κ x/∂η x) b).toReal ^ a ∂η x ∂μ
       - (a - 1)⁻¹ * (μ Set.univ).toReal := by
   simp_rw [condHellingerDiv_eq_integral'_of_one_lt ha_ne_zero ha h_int h_ac h_int',
-    compProd_univ_toReal, measure_univ, ENNReal.one_toReal, integral_const, smul_eq_mul, mul_one]
+    Measure.compProd_univ_toReal, measure_univ, ENNReal.one_toReal, integral_const, smul_eq_mul,
+    mul_one]
 
 lemma condHellingerDiv_eq_integral'_of_one_lt'' (ha_ne_zero : a ≠ 0) (ha : 1 < a)
     [IsProbabilityMeasure μ] [IsFiniteKernel κ] [IsMarkovKernel η]
@@ -928,14 +929,14 @@ lemma condHellingerDiv_eq_integral'_of_lt_one (ha_pos : 0 < a) (ha : a < 1) [IsF
       integral_sub (Integrable.const_mul h_int' _)
         (Integrable.const_mul (Integrable.kernel _ MeasurableSet.univ) _)
     _ = _ := by
-      rw [integral_mul_left, integral_mul_left, compProd_univ_toReal]
+      rw [integral_mul_left, integral_mul_left, Measure.compProd_univ_toReal]
 
 lemma condHellingerDiv_eq_integral'_of_lt_one' (ha_pos : 0 < a) (ha : a < 1) [IsFiniteMeasure μ]
     [IsFiniteKernel κ] [IsMarkovKernel η]
     (h_int' : Integrable (fun x ↦ ∫ b, ((∂κ x/∂η x) b).toReal ^ a ∂η x) μ) :
     condHellingerDiv a κ η μ = (a - 1)⁻¹ * ∫ x, ∫ b, ((∂κ x/∂η x) b).toReal ^ a ∂η x ∂μ
       - (a - 1)⁻¹ * (μ Set.univ).toReal := by
-  simp_rw [condHellingerDiv_eq_integral'_of_lt_one ha_pos ha h_int', compProd_univ_toReal,
+  simp_rw [condHellingerDiv_eq_integral'_of_lt_one ha_pos ha h_int', Measure.compProd_univ_toReal,
     measure_univ, ENNReal.one_toReal, integral_const, smul_eq_mul, mul_one]
 
 lemma condHellingerDiv_eq_integral'_of_lt_one'' (ha_pos : 0 < a) (ha : a < 1)

--- a/TestingLowerBounds/Hellinger.lean
+++ b/TestingLowerBounds/Hellinger.lean
@@ -3,9 +3,11 @@ Copyright (c) 2024 Rémy Degenne. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Rémy Degenne, Lorenzo Luccioli
 -/
-import TestingLowerBounds.FDiv.Basic
-import TestingLowerBounds.FDiv.CondFDiv
+-- theorem foo (n : Nat) : 0 ≤ n := by exact? -- trick to make exact? work TODO : erase this when we are done
+
+import TestingLowerBounds.KullbackLeibler
 import Mathlib.Analysis.Convex.SpecificFunctions.Pow
+import Mathlib.Tactic.FunProp.Measurable
 
 /-!
 # Helliger divergence
@@ -32,6 +34,9 @@ open scoped ENNReal NNReal Topology
 
 namespace ProbabilityTheory
 
+
+--TODO: try to add these attributes to fun_prop? how to do this?
+attribute [fun_prop] Measure.measurable_rnDeriv Measurable.ennreal_toReal
 variable {α : Type*} {mα : MeasurableSpace α} {μ ν : Measure α} {a : ℝ}
 
 -- todo: rename and move.
@@ -100,43 +105,95 @@ lemma integrable_rpow_rnDeriv_iff [SigmaFinite ν] [SigmaFinite μ] (hμν : μ 
 
 section HellingerFun
 
-/--Hellinger function, defined as `x ↦ (a - 1)⁻¹ * (x ^ a - 1)` for `a : ℝ`.-/
-noncomputable
-def hellingerFun (a : ℝ) : ℝ → ℝ := fun x ↦ (a - 1)⁻¹ * (x ^ a - 1)
+-- noncomputable
+-- def hellingerFun (a : ℝ) : ℝ → ℝ := fun x ↦ (a - 1)⁻¹ * (x ^ a - 1)
 
-lemma hellingerFun_one : hellingerFun 1 = fun x ↦ 0 := by
+/--Hellinger function, defined as `x ↦ (a - 1)⁻¹ * (x ^ a - 1)` for `a ∈ (0, 1) ∪ (1, + ∞)`.
+At `0` the function is obtained by contiuity and is the indicator function of `{0}`. At `1` it is
+defined as `x ↦ x * log x`, because in this way we obtain that the Hellinger divergence at `1`
+conincides with the KL divergence, which is natural for continuity reasons.-/
+noncomputable
+def hellingerFun (a : ℝ) : ℝ → ℝ :=
+  if a = 0 then fun x ↦ if x = 0 then 1 else 0
+  else if a = 1 then fun x ↦ x * log x
+  else fun x ↦ (a - 1)⁻¹ * (x ^ a - 1)
+
+lemma hellingerFun_zero : hellingerFun 0 = fun x ↦ if x = 0 then 1 else 0 := by
   ext x
   simp [hellingerFun]
+
+lemma hellingerFun_zero' : hellingerFun 0 = fun x ↦ 0 ^ x := by
+  ext x
+  by_cases h : x = 0
+    <;> simp [hellingerFun, h]
+
+lemma hellingerFun_zero'' : hellingerFun 0 = Set.indicator {0} 1 := by
+  ext x
+  by_cases h : x = 0
+    <;> simp [hellingerFun_zero, h]
+
+lemma hellingerFun_one : hellingerFun 1 = fun x ↦ x * log x := by
+  ext x
+  simp [hellingerFun]
+
+lemma hellingerFun_ne_zero_ne_one (ha_zero : a ≠ 0) (ha_one : a ≠ 1) :
+    hellingerFun a = fun x ↦ (a - 1)⁻¹ * (x ^ a - 1) := by
+  ext x
+  simp [hellingerFun, ha_zero, ha_one]
 
 lemma continuous_rpow_const (ha_pos : 0 < a) : Continuous fun (x : ℝ) ↦ x ^ a := by
   rw [continuous_iff_continuousAt]
   exact fun _ ↦ continuousAt_rpow_const _ _ (Or.inr ha_pos)
 
-lemma continuous_hellingerFun (ha_pos : 0 < a) : Continuous (hellingerFun a) :=
-  continuous_const.mul ((continuous_rpow_const ha_pos).sub continuous_const)
+lemma continuous_hellingerFun (ha_pos : 0 < a) : Continuous (hellingerFun a) := by
+  by_cases ha_eq : a = 1
+  · rw [ha_eq, hellingerFun_one]
+    simp [Real.continuous_mul_log]
+  rw [hellingerFun, if_neg ha_pos.ne', if_neg ha_eq]
+  exact continuous_const.mul ((continuous_rpow_const ha_pos).sub continuous_const)
 
-lemma stronglyMeasurable_hellingerFun (ha_pos : 0 < a) : StronglyMeasurable (hellingerFun a) :=
-  (continuous_hellingerFun ha_pos).stronglyMeasurable
+lemma stronglyMeasurable_hellingerFun (ha_nonneg : 0 ≤ a) :
+    StronglyMeasurable (hellingerFun a) := by
+  cases  (lt_or_eq_of_le ha_nonneg) with
+  | inl ha_pos => exact (continuous_hellingerFun ha_pos).stronglyMeasurable
+  | inr ha_eq =>
+    rw [← ha_eq, hellingerFun_zero'']
+    measurability
 
 @[simp]
-lemma hellingerFun_one_eq_zero : hellingerFun a 1 = 0 := by simp [hellingerFun]
+lemma hellingerFun_one_eq_zero : hellingerFun a 1 = 0 := by
+  by_cases ha_one : a = 1
+  · simp [ha_one, hellingerFun_one]
+  by_cases ha_zero : a = 0
+  · simp [ha_zero, hellingerFun_zero]
+  simp [hellingerFun, ha_one, ha_zero]
 
-lemma convexOn_hellingerFun (ha_pos : 0 < a) : ConvexOn ℝ (Set.Ici 0) (hellingerFun a) := by
-  cases le_total a 1 with
-  | inl ha =>
-    have : hellingerFun a = - (fun x ↦ (1 - a)⁻¹ • (x ^ a - 1)) := by
+lemma convexOn_hellingerFun (ha_pos : 0 ≤ a) : ConvexOn ℝ (Set.Ici 0) (hellingerFun a) := by
+  by_cases ha_zero : a = 0
+  · refine convexOn_iff_slope_mono_adjacent.mpr ?_
+    simp only [convex_Ici, Set.mem_Ici, smul_eq_mul, true_and, hellingerFun_zero, ha_zero]
+    intro x y z hx _ hxy hyz
+    simp only [(lt_of_le_of_lt hx hxy).ne', ↓reduceIte, zero_sub,
+      (gt_trans hyz <| lt_of_le_of_lt hx hxy).ne', sub_self, zero_div, div_nonpos_iff,
+      Left.nonneg_neg_iff, tsub_le_iff_right, zero_add, Left.neg_nonpos_iff, sub_nonneg]
+    right
+    exact ⟨by positivity, by linarith⟩
+  replace ha_pos := ha_pos.lt_of_ne fun h ↦ ha_zero h.symm
+  rcases (lt_trichotomy a 1) with (ha | ha | ha)
+  · have : hellingerFun a = - (fun x ↦ (1 - a)⁻¹ • (x ^ a - 1)) := by
       ext x
       simp only [Pi.neg_apply]
-      rw [smul_eq_mul, ← neg_mul, neg_inv, neg_sub, hellingerFun]
+      rw [hellingerFun_ne_zero_ne_one ha_pos.ne' ha.ne, smul_eq_mul, ← neg_mul, neg_inv, neg_sub]
     rw [this]
     refine ConcaveOn.neg ?_
-    exact ((Real.concaveOn_rpow ha_pos.le ha).sub (convexOn_const _ (convex_Ici 0))).smul
-      (by simp [ha])
-  | inr ha =>
-    have h := convexOn_rpow ha
+    exact ((Real.concaveOn_rpow ha_pos.le ha.le).sub (convexOn_const _ (convex_Ici 0))).smul
+      (by simp [ha.le])
+  · simp only [hellingerFun, ha, one_ne_zero, ↓reduceIte]
+    exact convexOn_mul_log
+  · have h := convexOn_rpow ha.le
     unfold hellingerFun
-    simp_rw [← smul_eq_mul]
-    refine ConvexOn.smul (by simp [ha]) ?_
+    simp_rw [← smul_eq_mul, if_neg ha_pos.ne', if_neg ha.ne']
+    refine ConvexOn.smul (by simp [ha.le]) ?_
     exact h.sub (concaveOn_const _ (convex_Ici 0))
 
 lemma tendsto_hellingerFun_div_atTop_of_one_lt (ha : 1 < a) :
@@ -151,83 +208,155 @@ lemma derivAtTop_hellingerFun_of_one_lt (ha : 1 < a) : derivAtTop (hellingerFun 
   rw [derivAtTop, if_pos]
   exact tendsto_hellingerFun_div_atTop_of_one_lt ha
 
+lemma derivAtTop_hellingerFun_of_one_le (ha : 1 ≤ a) :
+    derivAtTop (hellingerFun a) = ⊤ := by
+  by_cases ha_eq : a = 1
+  · simp only [hellingerFun, ha, ha_eq, one_ne_zero, ↓reduceIte]
+    exact derivAtTop_mul_log
+  · exact derivAtTop_hellingerFun_of_one_lt <| lt_of_le_of_ne ha fun ha ↦ ha_eq ha.symm
+
 lemma derivAtTop_hellingerFun_of_lt_one (ha : a < 1) :
     derivAtTop (hellingerFun a) = 0 :=
   derivAtTop_of_tendsto (tendsto_hellingerFun_div_atTop_of_lt_one ha)
 
-lemma derivAtTop_hellingerFun_of_le_one (ha : a ≤ 1) :
-    derivAtTop (hellingerFun a) = 0 := by
-  by_cases ha_eq : a = 1
-  · exact ha_eq.symm ▸ hellingerFun_one.symm ▸ derivAtTop_const 0
-  · exact derivAtTop_hellingerFun_of_lt_one <| lt_of_le_of_ne ha ha_eq
-
-lemma integrable_hellingerFun_iff_integrable_rpow [IsFiniteMeasure ν] (ha : a ≠ 1) :
+lemma integrable_hellingerFun_iff_integrable_rpow (ha_one : a ≠ 1) [IsFiniteMeasure ν] :
     Integrable (fun x ↦ hellingerFun a ((∂μ/∂ν) x).toReal) ν
       ↔ Integrable (fun x ↦ ((∂μ/∂ν) x).toReal ^ a) ν := by
-  simp_rw [hellingerFun]
-  rw [integrable_const_mul_iff]
-  swap; · simp [sub_eq_zero, ha]
+  by_cases ha_zero : a = 0
+  · simp_rw [ha_zero, hellingerFun_zero'', rpow_zero, integrable_const, iff_true,
+      ← Set.indicator_comp_right fun x ↦ ((∂μ/∂ν) x).toReal, Set.preimage, Set.mem_singleton_iff,
+      Pi.one_comp]
+    refine (integrable_indicator_iff ?_).mpr ?_
+    . apply measurableSet_eq_fun <;> fun_prop
+    . apply integrableOn_const.mpr
+      right
+      exact measure_lt_top ν _
+  rw [hellingerFun_ne_zero_ne_one ha_zero ha_one, integrable_const_mul_iff]
+  swap; · simp [sub_eq_zero, ha_one]
   simp_rw [sub_eq_add_neg, integrable_add_const_iff]
 
-lemma integrable_hellingerFun_rnDeriv_of_le_one (ha_pos : 0 < a) (ha : a ≤ 1) [IsFiniteMeasure μ]
+lemma integrable_hellingerFun_zero [IsFiniteMeasure ν] :
+    Integrable (fun x ↦ hellingerFun 0 ((∂μ/∂ν) x).toReal) ν := by
+  simp_rw [integrable_hellingerFun_iff_integrable_rpow zero_ne_one, rpow_zero]
+  exact integrable_const _
+
+lemma integrable_hellingerFun_rnDeriv_of_lt_one (ha_nonneg : 0 ≤ a) (ha : a < 1) [IsFiniteMeasure μ]
     [IsFiniteMeasure ν] :
     Integrable (fun x ↦ hellingerFun a ((∂μ/∂ν) x).toReal) ν := by
   refine integrable_f_rnDeriv_of_derivAtTop_ne_top μ ν ?_ ?_ ?_
-  · exact stronglyMeasurable_hellingerFun ha_pos
-  · exact convexOn_hellingerFun ha_pos
-  · rw [derivAtTop_hellingerFun_of_le_one ha]
+  · exact stronglyMeasurable_hellingerFun ha_nonneg
+  · exact convexOn_hellingerFun ha_nonneg
+  · rw [derivAtTop_hellingerFun_of_lt_one ha]
     exact EReal.zero_ne_top
 
-lemma integrable_rpow_rnDeriv_of_lt_one (ha_pos : 0 < a) (ha : a < 1) [IsFiniteMeasure μ]
+lemma integrable_rpow_rnDeriv_of_lt_one (ha_nonneg : 0 ≤ a) (ha : a < 1) [IsFiniteMeasure μ]
     [IsFiniteMeasure ν] :
     Integrable (fun x ↦ ((∂μ/∂ν) x).toReal ^ a) ν := by
   rw [← integrable_hellingerFun_iff_integrable_rpow ha.ne]
-  exact integrable_hellingerFun_rnDeriv_of_le_one ha_pos ha.le
+  exact integrable_hellingerFun_rnDeriv_of_lt_one ha_nonneg ha
 
 end HellingerFun
 
-/-- Hellinger divergence of order `a`. Meaningful for `a ∈ (0, 1) ∪ (1, ∞)`. -/
+/-- Hellinger divergence of order `a`.
+The cases `a = 0` and `a = 1` are defined separately inside the definition of the Hellinger
+function, so that in the case `a = 0` we have `hellingerDiv 0 μ ν = ν {x | (∂μ/∂ν) x = 0}`, and in
+the case `a = 1` the Hellinger divergence coincides with the KL divergence. -/
 noncomputable def hellingerDiv (a : ℝ) (μ ν : Measure α) : EReal := fDiv (hellingerFun a) μ ν
 
-@[simp]
-lemma hellingerDiv_one (μ ν : Measure α) : hellingerDiv 1 μ ν = 0 := by
-  rw [hellingerDiv, hellingerFun_one, fDiv_zero]
+lemma hellingerDiv_zero (μ ν : Measure α) :
+    hellingerDiv 0 μ ν = ν {x | ((∂μ/∂ν) x).toReal = 0} := by
+  have h_eq : (fun x ↦ Set.indicator {0} 1 (μ.rnDeriv ν x).toReal)
+      = {y | ((∂μ/∂ν) y).toReal = 0}.indicator (1 : α → ℝ) := by
+    simp_rw [← Set.indicator_comp_right fun x ↦ ((∂μ/∂ν) x).toReal, Set.preimage,
+      Set.mem_singleton_iff, Pi.one_comp]
+  have h_meas : MeasurableSet {y | (μ.rnDeriv ν y).toReal = 0} := by
+    apply measurableSet_eq_fun <;> fun_prop
+  by_cases h_int : Integrable (fun x ↦ hellingerFun 0 (μ.rnDeriv ν x).toReal) ν
+  swap
+  · rw [hellingerDiv, fDiv_of_not_integrable h_int]
+    rw [hellingerFun_zero'', h_eq, integrable_indicator_iff h_meas] at h_int
+    have := integrableOn_const.mpr.mt h_int
+    simp only [not_or, not_lt, top_le_iff] at this
+    rw [this.2, EReal.coe_ennreal_top]
+  rw [hellingerDiv, fDiv_of_integrable h_int, hellingerFun_zero'', h_eq, ← hellingerFun_zero'',
+    derivAtTop_hellingerFun_of_lt_one zero_lt_one, zero_mul, add_zero,
+    integral_indicator_one h_meas]
+  rw [hellingerFun_zero'', h_eq, integrable_indicator_iff h_meas, Pi.one_def] at h_int
+  apply integrableOn_const.mp at h_int
+  simp only [one_ne_zero, false_or] at h_int
+  exact EReal.coe_ennreal_toReal h_int.ne_top
+
+lemma hellingerDiv_zero' (μ ν : Measure α) [SigmaFinite μ] :
+    hellingerDiv 0 μ ν = ν {x | (∂μ/∂ν) x = 0} := by
+  rw [hellingerDiv_zero]
+  norm_cast
+  refine measure_congr <| eventuallyEq_set.mpr ?_
+  filter_upwards [Measure.rnDeriv_lt_top μ ν] with x hx
+  simp [ENNReal.toReal_eq_zero_iff, hx.ne]
+
+lemma hellingerDiv_zero'' (μ ν : Measure α) [SigmaFinite μ] [IsFiniteMeasure ν] :
+    hellingerDiv 0 μ ν = ν Set.univ - ν {x | 0 < (∂μ/∂ν) x} := by
+  have h : {x | μ.rnDeriv ν x = 0} = {x | 0 < μ.rnDeriv ν x}ᶜ := by
+    ext x
+    simp only [Set.mem_setOf_eq, Set.mem_compl_iff, not_lt, nonpos_iff_eq_zero, eq_comm]
+  rw [hellingerDiv_zero', h, measure_compl
+    (measurableSet_lt measurable_const (Measure.measurable_rnDeriv _ _)) (measure_ne_top _ _),
+    ENNReal.toEReal_sub (measure_ne_top _ _) (measure_mono _)]
+  exact fun _ _ ↦ trivial
+
+lemma hellingerDiv_zero_toReal (μ ν : Measure α) [SigmaFinite μ] [IsFiniteMeasure ν] :
+    (hellingerDiv 0 μ ν).toReal = (ν Set.univ).toReal - (ν {x | 0 < (∂μ/∂ν) x}).toReal := by
+  rw [hellingerDiv_zero'']
+  rw [EReal.toReal_sub]
+  all_goals simp [measure_ne_top]
+
+lemma hellingerDiv_zero_ne_top (μ ν : Measure α) [IsFiniteMeasure ν] :
+    hellingerDiv 0 μ ν ≠ ⊤ := by
+  rw [hellingerDiv_zero, ne_eq, EReal.coe_ennreal_eq_top_iff]
+  exact measure_ne_top _ _
+
+@[simp] lemma hellingerDiv_one (μ ν : Measure α) [SigmaFinite μ] [SigmaFinite ν] :
+    hellingerDiv 1 μ ν = kl μ ν := by
+  rw [hellingerDiv, hellingerFun_one, kl_eq_fDiv]
 
 section HellingerEq
 
 /--If `a ≤ 1` use `hellingerDiv_eq_integral_of_integrable_of_le_one` or
 `hellingerDiv_eq_integral_of_le_one`, as they have fewer hypotheses.-/
 lemma hellingerDiv_eq_integral_of_integrable_of_ac
-    (h_int : Integrable (fun x ↦ hellingerFun a ((∂μ/∂ν) x).toReal) ν) (h_ac : 1 < a → μ ≪ ν) :
+    (h_int : Integrable (fun x ↦ hellingerFun a ((∂μ/∂ν) x).toReal) ν) (h_ac : 1 ≤ a → μ ≪ ν) :
     hellingerDiv a μ ν = ∫ x, hellingerFun a ((∂μ/∂ν) x).toReal ∂ν := by
   rw [hellingerDiv, fDiv_of_integrable h_int]
-  rcases (lt_or_ge 1 a) with ha | ha
+  rcases (le_or_gt 1 a) with ha | ha
   · rw [Measure.singularPart_eq_zero_of_ac <| h_ac ha]
     norm_num
-  · rw [derivAtTop_hellingerFun_of_le_one ha]
+  · rw [derivAtTop_hellingerFun_of_lt_one ha]
     norm_num
 
-lemma hellingerDiv_eq_integral_of_integrable_of_le_one (ha : a ≤ 1)
+lemma hellingerDiv_eq_integral_of_integrable_of_lt_one (ha : a < 1)
     (h_int : Integrable (fun x ↦ hellingerFun a ((∂μ/∂ν) x).toReal) ν) :
     hellingerDiv a μ ν = ∫ x, hellingerFun a ((∂μ/∂ν) x).toReal ∂ν :=
-  hellingerDiv_eq_integral_of_integrable_of_ac h_int ha.not_lt.elim
+  hellingerDiv_eq_integral_of_integrable_of_ac h_int ha.not_le.elim
 
-lemma hellingerDiv_eq_integral_of_le_one (ha_pos : 0 < a) (ha : a ≤ 1) (μ ν : Measure α)
+
+lemma hellingerDiv_eq_integral_of_lt_one (ha_nonneg : 0 ≤ a) (ha : a < 1) (μ ν : Measure α)
     [IsFiniteMeasure μ] [IsFiniteMeasure ν] :
     hellingerDiv a μ ν = ∫ x, hellingerFun a ((∂μ/∂ν) x).toReal ∂ν :=
   hellingerDiv_eq_integral_of_integrable_of_ac
-    (integrable_hellingerFun_rnDeriv_of_le_one ha_pos ha) ha.not_lt.elim
+    (integrable_hellingerFun_rnDeriv_of_lt_one ha_nonneg ha) ha.not_le.elim
 
 lemma hellingerDiv_of_not_integrable
     (h : ¬ Integrable (fun x ↦ hellingerFun a ((∂μ/∂ν) x).toReal) ν) :
-    hellingerDiv a μ ν = ⊤ := fDiv_of_not_integrable h
+    hellingerDiv a μ ν = ⊤ :=
+  fDiv_of_not_integrable h
 
-lemma hellingerDiv_of_one_lt_not_ac (ha : 1 < a) (h_ac : ¬ μ ≪ ν) [SigmaFinite μ] [SigmaFinite ν] :
-    hellingerDiv a μ ν = ⊤ := fDiv_of_not_ac (derivAtTop_hellingerFun_of_one_lt ha) h_ac
+lemma hellingerDiv_of_one_lt_not_ac (ha : 1 ≤ a) (h_ac : ¬ μ ≪ ν) [SigmaFinite μ] [SigmaFinite ν] :
+    hellingerDiv a μ ν = ⊤ :=
+  fDiv_of_not_ac (derivAtTop_hellingerFun_of_one_le ha) h_ac
 
-lemma hellingerDiv_eq_top_iff (a : ℝ) (μ ν : Measure α) [SigmaFinite μ] [SigmaFinite ν] :
+lemma hellingerDiv_eq_top_iff (μ ν : Measure α) [SigmaFinite μ] [SigmaFinite ν] :
     hellingerDiv a μ ν = ⊤
-      ↔ ¬ Integrable (fun x ↦ hellingerFun a ((∂μ/∂ν) x).toReal) ν ∨ (1 < a ∧ ¬ μ ≪ ν) := by
+      ↔ ¬ Integrable (fun x ↦ hellingerFun a ((∂μ/∂ν) x).toReal) ν ∨ (1 ≤ a ∧ ¬ μ ≪ ν) := by
   constructor
   · contrapose!
     rintro ⟨h_int, h_ac⟩
@@ -237,61 +366,64 @@ lemma hellingerDiv_eq_top_iff (a : ℝ) (μ ν : Measure α) [SigmaFinite μ] [S
     · exact hellingerDiv_of_not_integrable h
     · exact hellingerDiv_of_one_lt_not_ac ha h_ac
 
-lemma hellingerDiv_ne_top_iff (a : ℝ) (μ ν : Measure α) [SigmaFinite μ] [SigmaFinite ν] :
+lemma hellingerDiv_ne_top_iff (μ ν : Measure α) [SigmaFinite μ] [SigmaFinite ν] :
     hellingerDiv a μ ν ≠ ⊤
-      ↔ Integrable (fun x ↦ hellingerFun a ((∂μ/∂ν) x).toReal) ν ∧ (1 < a → μ ≪ ν) := by
+      ↔ Integrable (fun x ↦ hellingerFun a ((∂μ/∂ν) x).toReal) ν ∧ (1 ≤ a → μ ≪ ν) := by
   rw [ne_eq, hellingerDiv_eq_top_iff]
   push_neg
   rfl
 
-lemma hellingerDiv_eq_top_iff_of_one_lt (ha : 1 < a) (μ ν : Measure α)
+lemma hellingerDiv_eq_top_iff_of_one_le (ha : 1 ≤ a) (μ ν : Measure α)
     [SigmaFinite μ] [SigmaFinite ν] :
     hellingerDiv a μ ν = ⊤
       ↔ ¬ Integrable (fun x ↦ hellingerFun a ((∂μ/∂ν) x).toReal) ν ∨ ¬ μ ≪ ν := by
   rw [hellingerDiv_eq_top_iff, and_iff_right ha]
 
-lemma hellingerDiv_ne_top_iff_of_one_lt (ha : 1 < a) (μ ν : Measure α)
+lemma hellingerDiv_ne_top_iff_of_one_le (ha : 1 ≤ a) (μ ν : Measure α)
     [SigmaFinite μ] [SigmaFinite ν] :
     hellingerDiv a μ ν ≠ ⊤
       ↔ Integrable (fun x ↦ hellingerFun a ((∂μ/∂ν) x).toReal) ν ∧ μ ≪ ν := by
-  rw [ne_eq, hellingerDiv_eq_top_iff_of_one_lt ha]
+  rw [ne_eq, hellingerDiv_eq_top_iff_of_one_le ha]
   push_neg
   rfl
 
-lemma hellingerDiv_eq_top_iff_of_le_one (ha : a ≤ 1) (μ ν : Measure α) :
+lemma hellingerDiv_eq_top_iff_of_lt_one (ha : a < 1) (μ ν : Measure α) :
     hellingerDiv a μ ν = ⊤ ↔ ¬ Integrable (fun x ↦ hellingerFun a ((∂μ/∂ν) x).toReal) ν := by
   refine ⟨?_, fun h ↦ hellingerDiv_of_not_integrable h⟩
   contrapose!
   rintro h_int
-  rw [hellingerDiv_eq_integral_of_integrable_of_le_one ha h_int]
+  rw [hellingerDiv_eq_integral_of_integrable_of_lt_one ha h_int]
   exact EReal.coe_ne_top _
 
-lemma hellingerDiv_ne_top_iff_of_le_one (ha : a ≤ 1) (μ ν : Measure α) :
+lemma hellingerDiv_ne_top_iff_of_lt_one (ha : a < 1) (μ ν : Measure α) :
     hellingerDiv a μ ν ≠ ⊤ ↔ Integrable (fun x ↦ hellingerFun a ((∂μ/∂ν) x).toReal) ν := by
-  rw [ne_eq, hellingerDiv_eq_top_iff_of_le_one ha, not_not]
+  rw [ne_eq, hellingerDiv_eq_top_iff_of_lt_one ha, not_not]
 
-lemma hellingerDiv_ne_top_of_le_one (ha_pos : 0 < a) (ha : a ≤ 1) (μ ν : Measure α)
+lemma hellingerDiv_ne_top_of_lt_one (ha_nonneg : 0 ≤ a) (ha : a < 1) (μ ν : Measure α)
     [IsFiniteMeasure μ] [IsFiniteMeasure ν] :
     hellingerDiv a μ ν ≠ ⊤ := by
-  rw [hellingerDiv_ne_top_iff_of_le_one ha]
-  exact integrable_hellingerFun_rnDeriv_of_le_one ha_pos ha
+  rw [hellingerDiv_ne_top_iff_of_lt_one ha]
+  exact integrable_hellingerFun_rnDeriv_of_lt_one ha_nonneg ha
 
 lemma hellingerDiv_eq_integral_of_ne_top [IsFiniteMeasure μ] [SigmaFinite ν]
-    (ha_ne_one : a ≠ 1) (h : hellingerDiv a μ ν ≠ ⊤) :
+    (h : hellingerDiv a μ ν ≠ ⊤) :
     hellingerDiv a μ ν = ∫ x, hellingerFun a ((∂μ/∂ν) x).toReal ∂ν := by
-  rw [hellingerDiv, fDiv_of_ne_top h]
-  cases lt_or_gt_of_ne ha_ne_one with
+  rw [hellingerDiv, fDiv_of_ne_top (by rwa [hellingerDiv] at h)]
+  cases lt_or_le a 1 with
   | inl ha_lt => rw [derivAtTop_hellingerFun_of_lt_one ha_lt, zero_mul, add_zero]
-  | inr ha_gt =>
-    rw [hellingerDiv_ne_top_iff_of_one_lt ha_gt] at h
+  | inr ha_ge =>
+    rw [hellingerDiv_ne_top_iff_of_one_le ha_ge] at h
     rw [Measure.singularPart_eq_zero_of_ac h.2]
     simp
 
-lemma hellingerDiv_eq_integral_of_ne_top' [IsFiniteMeasure μ] [IsFiniteMeasure ν]
-    (ha_ne_one : a ≠ 1) (h : hellingerDiv a μ ν ≠ ⊤) :
-    hellingerDiv a μ ν = (a - 1)⁻¹ * ∫ x, ((∂μ/∂ν) x).toReal ^ a ∂ν - (a - 1)⁻¹ *  ν Set.univ := by
-  rw [hellingerDiv_eq_integral_of_ne_top ha_ne_one h]
-  simp_rw [hellingerFun, integral_mul_left]
+/- Integral form of the Hellinger divergence:
+`Hₐ(μ, ν) = (a - 1)⁻¹ ∫ (dμ/dν) ^ a dν - (a - 1)⁻¹ ν(α)`.
+This lemma is not true for `a = 0`, because `0 ^ 0 = 1`. -/
+lemma hellingerDiv_eq_integral_of_ne_top' (ha_ne_zero : a ≠ 0) (ha_ne_one : a ≠ 1)
+    [IsFiniteMeasure μ] [IsFiniteMeasure ν] (h : hellingerDiv a μ ν ≠ ⊤) :
+    hellingerDiv a μ ν = (a - 1)⁻¹ * ∫ x, ((∂μ/∂ν) x).toReal ^ a ∂ν - (a - 1)⁻¹ * ν Set.univ := by
+  rw [hellingerDiv_eq_integral_of_ne_top h]
+  simp_rw [hellingerFun_ne_zero_ne_one ha_ne_zero ha_ne_one, integral_mul_left]
   rw [integral_sub _ (integrable_const _),
     integral_const, smul_eq_mul, mul_one, mul_sub, EReal.coe_sub, EReal.coe_mul, EReal.coe_mul,
     EReal.coe_ennreal_toReal (measure_ne_top _ _)]
@@ -299,28 +431,45 @@ lemma hellingerDiv_eq_integral_of_ne_top' [IsFiniteMeasure μ] [IsFiniteMeasure 
   by_contra h_not_int
   exact h (hellingerDiv_of_not_integrable h_not_int)
 
-lemma hellingerDiv_eq_integral_of_ne_top'' [IsFiniteMeasure μ] [IsProbabilityMeasure ν]
-    (ha_ne_one : a ≠ 1) (h : hellingerDiv a μ ν ≠ ⊤) :
+lemma hellingerDiv_eq_integral_of_ne_top'' (ha_ne_zero : a ≠ 0) (ha_ne_one : a ≠ 1)
+    [IsFiniteMeasure μ] [IsProbabilityMeasure ν] (h : hellingerDiv a μ ν ≠ ⊤) :
     hellingerDiv a μ ν = (a - 1)⁻¹ * ∫ x, ((∂μ/∂ν) x).toReal ^ a ∂ν - (a - 1)⁻¹ := by
-  rw [hellingerDiv_eq_integral_of_ne_top' ha_ne_one h]
+  rw [hellingerDiv_eq_integral_of_ne_top' ha_ne_zero ha_ne_one h]
   simp
 
 lemma hellingerDiv_eq_integral_of_lt_one' (ha_pos : 0 < a) (ha : a < 1) (μ ν : Measure α)
     [IsFiniteMeasure μ] [IsFiniteMeasure ν] :
-    hellingerDiv a μ ν = (a - 1)⁻¹ * ∫ x, ((∂μ/∂ν) x).toReal ^ a ∂ν - (a - 1)⁻¹ *  ν Set.univ :=
-  hellingerDiv_eq_integral_of_ne_top' ha.ne (hellingerDiv_ne_top_of_le_one ha_pos ha.le μ ν)
+    hellingerDiv a μ ν = (a - 1)⁻¹ * ∫ x, ((∂μ/∂ν) x).toReal ^ a ∂ν - (a - 1)⁻¹ * ν Set.univ :=
+  hellingerDiv_eq_integral_of_ne_top' ha_pos.ne.symm ha.ne
+    (hellingerDiv_ne_top_of_lt_one ha_pos.le ha μ ν)
+
+lemma hellingerDiv_toReal_of_lt_one (ha_pos : 0 < a) (ha : a < 1) (μ ν : Measure α)
+    [IsFiniteMeasure μ] [IsFiniteMeasure ν] :
+    (hellingerDiv a μ ν).toReal
+      = (a - 1)⁻¹ * ∫ x, ((∂μ/∂ν) x).toReal ^ a ∂ν - (a - 1)⁻¹ * (ν Set.univ).toReal := by
+  rw [hellingerDiv_eq_integral_of_lt_one' ha_pos ha, EReal.toReal_sub]
+  · simp [EReal.toReal_mul]
+  · exact EReal.coe_mul _ _ ▸ EReal.coe_ne_top _
+  · exact EReal.coe_mul _ _ ▸  EReal.coe_ne_bot _
+  · simp [ne_eq, EReal.mul_eq_top, measure_ne_top]
+  · simp [ne_eq, EReal.mul_eq_bot, measure_ne_top]
 
 end HellingerEq
 
 --Maybe we could write something like this for the conditional case? Would it be useful?
-lemma hellingerDiv_le_of_lt_one (ha_pos : 0 < a) (ha : a < 1) (μ ν : Measure α)
+lemma hellingerDiv_le_of_lt_one (ha_nonneg : 0 ≤ a) (ha : a < 1) (μ ν : Measure α)
     [IsFiniteMeasure μ] [IsFiniteMeasure ν] :
     hellingerDiv a μ ν ≤ (1 - a)⁻¹ * ν Set.univ := by
+  by_cases h_zero : a = 0
+  · rw [h_zero, hellingerDiv_zero']
+    simp only [inv_one, EReal.coe_one, one_mul, EReal.coe_ennreal_le_coe_ennreal_iff, sub_zero]
+    exact measure_mono fun _ _ ↦ trivial
   rw [hellingerDiv]
-  refine (fDiv_le_zero_add_top (stronglyMeasurable_hellingerFun ha_pos)
-    (convexOn_hellingerFun ha_pos)).trans_eq ?_
-  rw [derivAtTop_hellingerFun_of_lt_one ha, hellingerFun, zero_rpow ha_pos.ne']
-  simp only [zero_sub, mul_neg, mul_one, zero_mul, add_zero]
+  refine (fDiv_le_zero_add_top (stronglyMeasurable_hellingerFun ha_nonneg)
+    (convexOn_hellingerFun ha_nonneg)).trans_eq ?_
+  rw [derivAtTop_hellingerFun_of_lt_one ha, zero_mul, add_zero,
+    hellingerFun_ne_zero_ne_one h_zero ha.ne]
+  simp only [zero_sub, mul_neg, mul_one, zero_mul, add_zero, zero_rpow h_zero]
   rw [neg_inv, neg_sub]
 
 lemma hellingerDiv_symm' (ha_pos : 0 < a) (ha : a < 1) (h_eq : μ Set.univ = ν Set.univ)
@@ -346,59 +495,67 @@ lemma hellingerDiv_symm (ha_pos : 0 < a) (ha : a < 1)
     (1 - a) * hellingerDiv a μ ν = a * hellingerDiv (1 - a) ν μ :=
   hellingerDiv_symm' ha_pos ha (by simp)
 
-lemma hellingerDiv_nonneg (ha_pos : 0 < a) (μ ν : Measure α) [IsProbabilityMeasure μ] [IsProbabilityMeasure ν] :
-    0 ≤ hellingerDiv a μ ν :=
-  fDiv_nonneg (convexOn_hellingerFun ha_pos) (continuous_hellingerFun ha_pos).continuousOn
+lemma hellingerDiv_zero_nonneg (μ ν : Measure α) :
+    0 ≤ hellingerDiv 0 μ ν := hellingerDiv_zero _ _ ▸ EReal.coe_ennreal_nonneg _
+
+lemma hellingerDiv_nonneg (ha_pos : 0 ≤ a) (μ ν : Measure α)
+    [IsProbabilityMeasure μ] [IsProbabilityMeasure ν] :
+    0 ≤ hellingerDiv a μ ν := by
+  by_cases h_zero : a = 0
+  · exact h_zero ▸ hellingerDiv_zero_nonneg μ ν
+  replace ha_pos := ha_pos.lt_of_ne fun h ↦ h_zero h.symm
+  rw [hellingerDiv]
+  exact fDiv_nonneg (convexOn_hellingerFun ha_pos.le) (continuous_hellingerFun ha_pos).continuousOn
     hellingerFun_one_eq_zero
 
 section Conditional
 
 variable {β : Type*} {mβ : MeasurableSpace β} {κ η : kernel α β}
 
-lemma hellingerDiv_ae_ne_top_iff (a : ℝ) (κ η : kernel α β) [IsFiniteKernel κ] [IsFiniteKernel η] :
+lemma hellingerDiv_ae_ne_top_iff (κ η : kernel α β) [IsFiniteKernel κ] [IsFiniteKernel η] :
     (∀ᵐ x ∂μ, hellingerDiv a (κ x) (η x) ≠ ⊤)
       ↔ (∀ᵐ x ∂μ, Integrable (fun b ↦ hellingerFun a ((∂κ x/∂η x) b).toReal) (η x))
-        ∧ (1 < a → ∀ᵐ x ∂μ, (κ x) ≪ (η x)) := by
+        ∧ (1 ≤ a → ∀ᵐ x ∂μ, (κ x) ≪ (η x)) := by
   simp_rw [hellingerDiv_ne_top_iff, eventually_and, eventually_all]
 
-lemma hellingerDiv_ae_ne_top_iff_of_le_one (ha : a ≤ 1) (κ η : kernel α β) :
+lemma hellingerDiv_ae_ne_top_iff_of_lt_one (ha : a < 1) (κ η : kernel α β) :
     (∀ᵐ x ∂μ, hellingerDiv a (κ x) (η x) ≠ ⊤)
       ↔ (∀ᵐ x ∂μ, Integrable (fun b ↦ hellingerFun a ((∂κ x/∂η x) b).toReal) (η x)) := by
-  simp_rw [hellingerDiv_ne_top_iff_of_le_one ha]
+  simp_rw [hellingerDiv_ne_top_iff_of_lt_one ha]
 
 /--Use this version only for the case `1 < a` or when one of the kernels is not finite, otherwise
 use `integrable_hellingerDiv_iff_of_lt_one`, as it is strictly more general.-/
 lemma integrable_hellingerDiv_iff
     (h_int : ∀ᵐ x ∂μ, Integrable (fun b ↦ hellingerFun a ((∂κ x/∂η x) b).toReal) (η x))
-    (h_ac : 1 < a → ∀ᵐ x ∂μ, κ x ≪ η x) :
+    (h_ac : 1 ≤ a → ∀ᵐ x ∂μ, κ x ≪ η x) :
     Integrable (fun x ↦ (hellingerDiv a (κ x) (η x)).toReal) μ
       ↔ Integrable (fun x ↦ ∫ b, hellingerFun a ((∂κ x/∂η x) b).toReal ∂η x) μ := by
   apply integrable_congr
   filter_upwards [h_int, eventually_all.mpr h_ac] with x hx_int hx_ac
   rw [hellingerDiv_eq_integral_of_integrable_of_ac hx_int hx_ac, EReal.toReal_coe]
 
-lemma integrable_hellingerDiv_iff_of_le_one [IsFiniteKernel κ] [IsFiniteKernel η] (ha_pos : 0 < a)
-    (ha : a ≤ 1) :
+lemma integrable_hellingerDiv_iff_of_lt_one (ha_nonneg : 0 ≤ a) (ha : a < 1)
+    [IsFiniteKernel κ] [IsFiniteKernel η] :
     Integrable (fun x ↦ (hellingerDiv a (κ x) (η x)).toReal) μ
       ↔ Integrable (fun x ↦ ∫ b, hellingerFun a ((∂κ x/∂η x) b).toReal ∂η x) μ := by
   refine integrable_congr (eventually_of_forall fun x ↦ ?_)
-  simp_rw [hellingerDiv_eq_integral_of_le_one ha_pos ha, EReal.toReal_coe]
+  simp_rw [hellingerDiv_eq_integral_of_lt_one ha_nonneg ha, EReal.toReal_coe]
 
-lemma integrable_hellingerDiv_iff' [IsFiniteMeasure μ] [IsFiniteKernel κ] [IsFiniteKernel η]
-    (ha_pos : 0 < a) (ha_ne_one : a ≠ 1)
+lemma integrable_hellingerDiv_iff' (ha_pos : 0 < a) (ha_ne_one : a ≠ 1) [IsFiniteMeasure μ]
+    [IsFiniteKernel κ] [IsFiniteKernel η]
     (h_int : ∀ᵐ x ∂μ, Integrable (fun b ↦ hellingerFun a ((∂κ x/∂η x) b).toReal) (η x))
-    (h_ac : 1 < a → ∀ᵐ x ∂μ, κ x ≪ η x) :
+    (h_ac : 1 ≤ a → ∀ᵐ x ∂μ, κ x ≪ η x) :
     Integrable (fun x ↦ (hellingerDiv a (κ x) (η x)).toReal) μ
       ↔ Integrable (fun x ↦ ∫ b, ((∂κ x/∂η x) b).toReal ^ a ∂η x) μ := by
   have h_fin : ∀ᵐ x ∂μ, hellingerDiv a (κ x) (η x) ≠ ⊤ := by
     filter_upwards [h_int, eventually_all.mpr h_ac] with x hx_int hx_ac
-    rcases lt_or_gt_of_ne ha_ne_one with h_lt | h_gt
-    · exact hellingerDiv_ne_top_of_le_one ha_pos h_lt.le _ _
-    · exact hellingerDiv_ne_top_iff_of_one_lt h_gt _ _ |>.mpr ⟨hx_int, hx_ac h_gt⟩
+    rcases lt_or_ge a 1 with h_lt | h_ge
+    · exact hellingerDiv_ne_top_of_lt_one ha_pos.le h_lt _ _
+    · exact hellingerDiv_ne_top_iff_of_one_le h_ge _ _ |>.mpr ⟨hx_int, hx_ac h_ge⟩
   have h_eq_eq : ∀ᵐ x ∂μ, (hellingerDiv a (κ x) (η x)).toReal =
       (a - 1)⁻¹ * ((∫ b, ((∂κ x/∂η x) b).toReal ^ a ∂η x) - ((η x) Set.univ).toReal) := by
     filter_upwards [h_fin] with x hx
-    rw [hellingerDiv_eq_integral_of_ne_top' ha_ne_one hx, ← EReal.coe_mul,
+    rw [hellingerDiv_eq_integral_of_ne_top' ha_pos.ne.symm ha_ne_one hx, ← EReal.coe_mul,
       EReal.toReal_sub (EReal.coe_ne_top _) (EReal.coe_ne_bot _), EReal.toReal_coe,
       EReal.toReal_mul, EReal.toReal_coe, EReal.toReal_coe_ennreal, mul_sub]
     · refine (EReal.mul_eq_top _ _).mp.mt ?_
@@ -421,34 +578,92 @@ lemma integrable_hellingerDiv_iff' [IsFiniteMeasure μ] [IsFiniteKernel κ] [IsF
     (measure_ne_top _ _) (lt_top_iff_ne_top.mp hC_finite)]
   exact hC x
 
-lemma integrable_hellingerDiv_iff'_of_lt_one [IsFiniteMeasure μ] [IsFiniteKernel κ]
-    [IsFiniteKernel η] (ha_pos : 0 < a) (ha : a < 1) :
+--TODO: shouldn't Set.setOf_app_iff be a simp lemma?
+
+lemma integrable_hellingerDiv_zero [MeasurableSpace.CountableOrCountablyGenerated α β]
+    [IsFiniteMeasure μ] [IsFiniteKernel κ] [IsFiniteKernel η] :
+    Integrable (fun x ↦ (hellingerDiv 0 (κ x) (η x)).toReal) μ := by
+  simp_rw [hellingerDiv_zero]
+  obtain ⟨C, ⟨hC_finite, hC⟩⟩ := IsFiniteKernel.exists_univ_le (κ := η)
+  simp only [EReal.toReal_coe_ennreal]
+  have h_eq : (fun x ↦ ((η x) {y | ((κ x).rnDeriv (η x) y).toReal = 0}).toReal) =
+      fun x ↦ ((η x) {y | (kernel.rnDeriv κ η x y).toReal = 0}).toReal := by
+    ext x
+    congr 1
+    apply measure_congr
+    filter_upwards [kernel.rnDeriv_eq_rnDeriv_measure κ η x] with y hy
+    simp only [Set.setOf_app_iff, eq_iff_iff, hy]
+  simp_rw [h_eq]
+  apply (integrable_const C.toReal).mono'
+  · apply Measurable.aestronglyMeasurable
+    apply Measurable.ennreal_toReal
+    exact kernel.measurable_kernel_prod_mk_left
+      (measurableSet_eq_fun (kernel.measurable_rnDeriv _ _).ennreal_toReal measurable_const)
+  · refine eventually_of_forall (fun x ↦ ?_)
+    simp only [norm_eq_abs, ENNReal.abs_toReal, ENNReal.toReal_le_toReal
+    (measure_ne_top _ _) (lt_top_iff_ne_top.mp hC_finite)]
+    exact measure_mono (Set.subset_univ _) |>.trans (hC x)
+
+lemma integrable_hellingerDiv_iff'_of_lt_one (ha_pos : 0 < a) (ha : a < 1) [IsFiniteMeasure μ]
+    [IsFiniteKernel κ] [IsFiniteKernel η] :
     Integrable (fun x ↦ (hellingerDiv a (κ x) (η x)).toReal) μ
       ↔ Integrable (fun x ↦ ∫ b, ((∂κ x/∂η x) b).toReal ^ a ∂η x) μ :=
   integrable_hellingerDiv_iff' ha_pos ha.ne (eventually_of_forall
-    (fun _ ↦ integrable_hellingerFun_rnDeriv_of_le_one ha_pos ha.le)) (not_lt_of_gt ha).elim
+    (fun _ ↦ integrable_hellingerFun_rnDeriv_of_lt_one ha_pos.le ha)) (not_le_of_gt ha).elim
 
 /-- Conditional Hellinger divergence of order `a`. Meaningful for `a ∈ (0, 1) ∪ (1, ∞)`. -/
 noncomputable def condHellingerDiv (a : ℝ) (κ η : kernel α β) (μ : Measure α) : EReal :=
   condFDiv (hellingerFun a) κ η μ
 
+/-! There are multiple combinations of hypotheses that give rise to slightly different versions of
+the following lemmas. The ones we will consider as a normal form are when we assume that `μ`, `κ`
+and `η` are all finite and `a ∈ (0, 1) ∪ (1, +∞)`.
+
+Consider the following conditions:
+1. `condHellingerDiv a κ η μ ≠ ⊤`
+2. `condHellingerDiv a κ η μ = ∫ x, (hellingerDiv a (κ x) (η x)).toReal ∂μ`
+3.a `∀ᵐ x ∂μ, Integrable (fun b ↦ hellingerFun a ((∂κ x/∂η x) b).toReal) (η x)` (`h_int`)
+3.b `∀ᵐ x ∂μ, (κ x) ≪ (η x)` (`h_ac`)
+3.c `Integrable (fun x ↦ ∫ b, ((∂κ x/∂η x) b).toReal ^ a ∂η x) μ` (`h_int'`)
+4. `condHellingerDiv a κ η μ = (a - 1)⁻¹ * ∫ x, ∫ b, ((∂κ x/∂η x) b).toReal ^ a ∂η x ∂μ - (a - 1)⁻¹ * ((μ ⊗ₘ η) Set.univ).toReal`
+
+Then the following hold:
+- 1. ↔ 2. (`condHellingerDiv_eq_integral_iff_ne_top`)
+- if `1 < a`:
+  - 1. ↔ 3.a ∧ 3.b ∧ 3.c (`condHellingerDiv_ne_top_iff_of_one_lt`)
+  - 2. ↔ 3.a ∧ 3.b ∧ 3.c (`condHellingerDiv_eq_integral_iff_of_one_lt`)
+  - 3.a ∧ 3.b ∧ 3.c → 4. (`condHellingerDiv_eq_integral'_of_one_lt`)
+- if `a < 1`:
+  - 1. ↔ 3.c (`condHellingerDiv_ne_top_iff_of_lt_one`)
+  - 2. ↔ 3.c (`condHellingerDiv_eq_integral_iff_of_lt_one`)
+  - 3.c → 4. (`condHellingerDiv_eq_integral'_of_lt_one`)
+
+The implications 4. → 1./2./3. are not explicitely stated but, if needed, it should be immediate to
+prove 4. → 1. and then have all the other implications for free.
+-/
 section CondHellingerEq
 
+lemma condHellingerDiv_one [IsFiniteKernel κ] [IsFiniteKernel η] :
+    condHellingerDiv 1 κ η μ = condKL κ η μ := by
+  rw [condHellingerDiv, hellingerFun_one, condKL_eq_condFDiv]
+
 lemma condHellingerDiv_of_not_ae_finite (h_ae : ¬ ∀ᵐ x ∂μ, hellingerDiv a (κ x) (η x) ≠ ⊤) :
-    condHellingerDiv a κ η μ = ⊤ := condFDiv_of_not_ae_finite h_ae
+    condHellingerDiv a κ η μ = ⊤ := by
+  rw [condHellingerDiv]
+  exact condFDiv_of_not_ae_finite h_ae
 
 lemma condHellingerDiv_of_not_ae_integrable [IsFiniteKernel κ] [IsFiniteKernel η]
     (h_int : ¬ ∀ᵐ x ∂μ, Integrable (fun b ↦ hellingerFun a ((∂κ x/∂η x) b).toReal) (η x)) :
     condHellingerDiv a κ η μ = ⊤ := condFDiv_of_not_ae_integrable h_int
 
-lemma condHellingerDiv_of_not_ae_integrable_of_le_one (ha : a ≤ 1)
+lemma condHellingerDiv_of_not_ae_integrable_of_le_one (ha : a < 1)
     (h_int : ¬ ∀ᵐ x ∂μ, Integrable (fun b ↦ hellingerFun a ((∂κ x/∂η x) b).toReal) (η x)) :
     condHellingerDiv a κ η μ = ⊤ := by
   apply condHellingerDiv_of_not_ae_finite
-  rw [hellingerDiv_ae_ne_top_iff_of_le_one ha]
+  rw [hellingerDiv_ae_ne_top_iff_of_lt_one ha]
   exact h_int
 
-lemma condHellingerDiv_of_not_ae_ac_of_one_lt [IsFiniteKernel κ] [IsFiniteKernel η] (ha : 1 < a)
+lemma condHellingerDiv_of_not_ae_ac_of_one_le (ha : 1 ≤ a) [IsFiniteKernel κ] [IsFiniteKernel η]
     (h_ac : ¬ ∀ᵐ x ∂μ, (κ x) ≪ (η x)) :
     condHellingerDiv a κ η μ = ⊤ := by
   apply condHellingerDiv_of_not_ae_finite
@@ -459,76 +674,292 @@ lemma condHellingerDiv_of_not_integrable
     (h_int : ¬ Integrable (fun x ↦ (hellingerDiv a (κ x) (η x)).toReal) μ) :
     condHellingerDiv a κ η μ = ⊤ := condFDiv_of_not_integrable h_int
 
-lemma condHellingerDiv_of_not_integrable' (ha_pos : 0 < a) (ha_ne_one : a ≠ 1) [IsFiniteMeasure μ]
-    [IsFiniteKernel κ] [IsFiniteKernel η]
-    (h_int : ¬ Integrable (fun x ↦ ∫ b, ((∂κ x/∂η x) b).toReal ^ a ∂η x) μ) :
+lemma condHellingerDiv_of_not_integrable' (ha_nonneg : 0 ≤ a) (ha_ne_one : a ≠ 1)
+    [IsFiniteMeasure μ] [IsFiniteKernel κ] [IsFiniteKernel η]
+    (h_int' : ¬ Integrable (fun x ↦ ∫ b, ((∂κ x/∂η x) b).toReal ^ a ∂η x) μ) :
     condHellingerDiv a κ η μ = ⊤ := by
+  by_cases ha_zero : a = 0
+  · simp [ha_zero, Integrable.kernel] at h_int'
+  have ha_pos := ha_nonneg.lt_of_ne fun h ↦ ha_zero h.symm
   by_cases h_int2 : ∀ᵐ x ∂μ, Integrable (fun b ↦ hellingerFun a ((∂κ x/∂η x) b).toReal) (η x)
   swap; exact condHellingerDiv_of_not_ae_integrable h_int2
-  by_cases h_ac : 1 < a → ∀ᵐ x ∂μ, κ x ≪ η x
+  by_cases h_ac : 1 ≤ a → ∀ᵐ x ∂μ, κ x ≪ η x
   swap
   · push_neg at h_ac
-    exact condHellingerDiv_of_not_ae_ac_of_one_lt h_ac.1 h_ac.2
+    exact condHellingerDiv_of_not_ae_ac_of_one_le h_ac.1 h_ac.2
   apply condHellingerDiv_of_not_integrable
   rwa [integrable_hellingerDiv_iff' ha_pos ha_ne_one h_int2 h_ac]
 
 lemma condHellingerDiv_of_ae_finite_of_integrable (h_ae : ∀ᵐ x ∂μ, hellingerDiv a (κ x) (η x) ≠ ⊤)
-    (h_int : Integrable (fun x ↦ (hellingerDiv a (κ x) (η x)).toReal) μ) :
+    (h_int2 : Integrable (fun x ↦ (hellingerDiv a (κ x) (η x)).toReal) μ) :
     condHellingerDiv a κ η μ = ∫ x, (hellingerDiv a (κ x) (η x)).toReal ∂μ :=
-  condFDiv_eq' h_ae h_int
+  condFDiv_eq' h_ae h_int2
 
 lemma condHellingerDiv_of_ae_integrable_of_ae_ac_of_integrable [IsFiniteKernel κ] [IsFiniteKernel η]
     (h_int : ∀ᵐ x ∂μ, Integrable (fun b ↦ hellingerFun a ((∂κ x/∂η x) b).toReal) (η x))
-    (h_ac : 1 < a → ∀ᵐ x ∂μ, (κ x) ≪ (η x))
+    (h_ac : 1 ≤ a → ∀ᵐ x ∂μ, (κ x) ≪ (η x))
     (h_int2 : Integrable (fun x ↦ (hellingerDiv a (κ x) (η x)).toReal) μ) :
     condHellingerDiv a κ η μ = ∫ x, (hellingerDiv a (κ x) (η x)).toReal ∂μ :=
   condHellingerDiv_of_ae_finite_of_integrable
-    ((hellingerDiv_ae_ne_top_iff _ _ _).mpr ⟨h_int, h_ac⟩) h_int2
+    ((hellingerDiv_ae_ne_top_iff _ _).mpr ⟨h_int, h_ac⟩) h_int2
 
-lemma condHellingerDiv_of_ae_integrable_of_integrable_of_le_one (ha : a ≤ 1)
+lemma condHellingerDiv_zero_eq [MeasurableSpace.CountableOrCountablyGenerated α β]
+    [IsFiniteMeasure μ] [IsFiniteKernel κ] [IsFiniteKernel η] :
+    condHellingerDiv 0 κ η μ = ∫ x, (hellingerDiv 0 (κ x) (η x)).toReal ∂μ :=
+  condHellingerDiv_of_ae_finite_of_integrable
+    ((hellingerDiv_ae_ne_top_iff _ _).mpr
+      ⟨eventually_of_forall (fun _ ↦ integrable_hellingerFun_zero), by simp⟩)
+    integrable_hellingerDiv_zero
+
+lemma condHellingerDiv_zero_of_ae_integrable_of_integrable
+    [IsFiniteMeasure μ] [IsFiniteKernel κ] [IsFiniteKernel η]
+    (h_int2 : Integrable (fun x ↦ (hellingerDiv 0 (κ x) (η x)).toReal) μ) :
+    condHellingerDiv 0 κ η μ = ∫ x, (hellingerDiv 0 (κ x) (η x)).toReal ∂μ :=
+  condHellingerDiv_of_ae_finite_of_integrable
+    ((hellingerDiv_ae_ne_top_iff _ _).mpr
+      ⟨eventually_of_forall (fun _ ↦ integrable_hellingerFun_zero), by simp⟩) h_int2
+
+--TODO: try to generalize this to the case `a = 0`
+lemma condHellingerDiv_of_ae_integrable_of_ae_ac_of_integrable' (ha_pos : 0 < a) (ha_ne_one : a ≠ 1)
+    [IsFiniteMeasure μ] [IsFiniteKernel κ] [IsFiniteKernel η]
+    (h_int : ∀ᵐ x ∂μ, Integrable (fun b ↦ hellingerFun a ((∂κ x/∂η x) b).toReal) (η x))
+    (h_ac : 1 ≤ a → ∀ᵐ x ∂μ, (κ x) ≪ (η x))
+    (h_int' : Integrable (fun x ↦ ∫ b, ((∂κ x/∂η x) b).toReal ^ a ∂η x) μ) :
+    condHellingerDiv a κ η μ = ∫ x, (hellingerDiv a (κ x) (η x)).toReal ∂μ :=
+  condHellingerDiv_of_ae_finite_of_integrable
+    ((hellingerDiv_ae_ne_top_iff _ _).mpr ⟨h_int, h_ac⟩)
+    (integrable_hellingerDiv_iff' ha_pos ha_ne_one h_int h_ac |>.mpr h_int')
+
+lemma condHellingerDiv_of_ae_integrable_of_integrable_of_lt_one (ha : a < 1)
     (h_int : ∀ᵐ x ∂μ, Integrable (fun b ↦ hellingerFun a ((∂κ x/∂η x) b).toReal) (η x))
     (h_int2 : Integrable (fun x ↦ (hellingerDiv a (κ x) (η x)).toReal) μ) :
     condHellingerDiv a κ η μ = ∫ x, (hellingerDiv a (κ x) (η x)).toReal ∂μ :=
   condHellingerDiv_of_ae_finite_of_integrable
-    ((hellingerDiv_ae_ne_top_iff_of_le_one ha _ _).mpr h_int) h_int2
+    ((hellingerDiv_ae_ne_top_iff_of_lt_one ha _ _).mpr h_int) h_int2
+
+lemma condHellingerDiv_of_integrable'_of_lt_one (ha_pos : 0 < a) (ha : a < 1)
+    [IsFiniteMeasure μ] [IsFiniteKernel κ] [IsFiniteKernel η]
+    (h_int' : Integrable (fun x ↦ ∫ b, ((∂κ x/∂η x) b).toReal ^ a ∂η x) μ) :
+    condHellingerDiv a κ η μ = ∫ x, (hellingerDiv a (κ x) (η x)).toReal ∂μ :=
+  condHellingerDiv_of_ae_finite_of_integrable
+    ((hellingerDiv_ae_ne_top_iff_of_lt_one ha _ _).mpr
+      (eventually_of_forall <| fun _ ↦ integrable_hellingerFun_rnDeriv_of_lt_one ha_pos.le ha))
+    (integrable_hellingerDiv_iff'_of_lt_one ha_pos ha |>.mpr h_int')
 
 lemma condHellingerDiv_eq_top_iff [IsFiniteKernel κ] [IsFiniteKernel η] :
     condHellingerDiv a κ η μ = ⊤
       ↔ ¬ (∀ᵐ x ∂μ, Integrable (fun b ↦ hellingerFun a ((∂κ x/∂η x) b).toReal) (η x))
-        ∨ (1 < a ∧ ¬ ∀ᵐ x ∂μ, (κ x) ≪ (η x))
+        ∨ (1 ≤ a ∧ ¬ ∀ᵐ x ∂μ, (κ x) ≪ (η x))
         ∨ ¬ Integrable (fun x ↦ (hellingerDiv a (κ x) (η x)).toReal) μ := by
   constructor
   · contrapose!
     rintro ⟨h_int, h_ac, h_int2⟩
     rw [condHellingerDiv_of_ae_integrable_of_ae_ac_of_integrable h_int h_ac h_int2]
     exact EReal.coe_ne_top _
-  · rintro (h | ⟨ha, h_ac⟩ | h_int)
-    · exact condHellingerDiv_of_not_ae_integrable h
-    · exact condHellingerDiv_of_not_ae_ac_of_one_lt ha h_ac
-    · exact condHellingerDiv_of_not_integrable h_int
+  · rintro (h_int | ⟨ha, h_ac⟩ | h_int2)
+    · exact condHellingerDiv_of_not_ae_integrable h_int
+    · exact condHellingerDiv_of_not_ae_ac_of_one_le ha h_ac
+    · exact condHellingerDiv_of_not_integrable h_int2
 
 lemma condHellingerDiv_ne_top_iff [IsFiniteKernel κ] [IsFiniteKernel η] :
     condHellingerDiv a κ η μ ≠ ⊤
       ↔ (∀ᵐ x ∂μ, Integrable (fun b ↦ hellingerFun a ((∂κ x/∂η x) b).toReal) (η x))
-        ∧ (1 < a →  ∀ᵐ x ∂μ, (κ x) ≪ (η x))
+        ∧ (1 ≤ a → ∀ᵐ x ∂μ, (κ x) ≪ (η x))
         ∧ Integrable (fun x ↦ (hellingerDiv a (κ x) (η x)).toReal) μ := by
   rw [ne_eq, condHellingerDiv_eq_top_iff]
   push_neg
   rfl
 
-lemma condHellingerDiv_ne_top_iff_of_le_one (ha : a ≤ 1) [IsFiniteKernel κ] [IsFiniteKernel η] :
+lemma condHellingerDiv_ne_top_iff' (ha_pos : 0 < a) (ha_ne_one : a ≠ 1) [IsFiniteMeasure μ]
+    [IsFiniteKernel κ] [IsFiniteKernel η] :
+    condHellingerDiv a κ η μ ≠ ⊤
+      ↔ (∀ᵐ x ∂μ, Integrable (fun b ↦ hellingerFun a ((∂κ x/∂η x) b).toReal) (η x))
+        ∧ (1 ≤ a → ∀ᵐ x ∂μ, (κ x) ≪ (η x))
+        ∧ Integrable (fun x ↦ ∫ b, ((∂κ x/∂η x) b).toReal ^ a ∂η x) μ := by
+  simp_rw [condHellingerDiv_ne_top_iff]
+  refine and_congr_right (fun h_int ↦ and_congr_right (fun h_ac ↦ ?_))
+  rw [integrable_hellingerDiv_iff' ha_pos ha_ne_one h_int h_ac]
+
+lemma condHellingerDiv_ne_top_iff_of_one_lt (ha : 1 < a) [IsFiniteMeasure μ]
+    [IsFiniteKernel κ] [IsFiniteKernel η] :
+    condHellingerDiv a κ η μ ≠ ⊤
+      ↔ (∀ᵐ x ∂μ, Integrable (fun b ↦ hellingerFun a ((∂κ x/∂η x) b).toReal) (η x))
+        ∧ (∀ᵐ x ∂μ, (κ x) ≪ (η x))
+        ∧ Integrable (fun x ↦ ∫ b, ((∂κ x/∂η x) b).toReal ^ a ∂η x) μ := by
+  simp_rw [condHellingerDiv_ne_top_iff' (zero_lt_one.trans ha) ha.ne.symm, ha.le, true_implies]
+
+lemma condHellingerDiv_eq_top_iff_of_one_lt (ha : 1 < a) [IsFiniteMeasure μ]
+    [IsFiniteKernel κ] [IsFiniteKernel η] :
+    condHellingerDiv a κ η μ = ⊤
+      ↔ ¬ (∀ᵐ x ∂μ, Integrable (fun b ↦ hellingerFun a ((∂κ x/∂η x) b).toReal) (η x))
+        ∨ (1 ≤ a ∧ ¬ ∀ᵐ x ∂μ, (κ x) ≪ (η x))
+        ∨ ¬ Integrable (fun x ↦ ∫ b, ((∂κ x/∂η x) b).toReal ^ a ∂η x) μ := by
+  rw [← not_not (a := _ = ⊤), ← ne_eq, condHellingerDiv_ne_top_iff_of_one_lt ha]
+  have ha' : 1 ≤ a := ha.le
+  tauto
+
+lemma condHellingerDiv_eq_top_iff_of_lt_one (ha : a < 1) [IsFiniteKernel κ] [IsFiniteKernel η] :
     condHellingerDiv a κ η μ = ⊤
       ↔ ¬ (∀ᵐ x ∂μ, Integrable (fun b ↦ hellingerFun a ((∂κ x/∂η x) b).toReal) (η x))
         ∨ ¬ Integrable (fun x ↦ (hellingerDiv a (κ x) (η x)).toReal) μ := by
-  simp only [condHellingerDiv_eq_top_iff, not_eventually, ha.not_lt, false_and, false_or]
+  simp only [condHellingerDiv_eq_top_iff, not_eventually, ha.not_le, false_and, false_or]
 
-lemma condHellingerDiv_eq_top_iff_of_le_one (ha : a ≤ 1) [IsFiniteKernel κ] [IsFiniteKernel η] :
+lemma condHellingerDiv_ne_top_iff_of_le_one (ha : a < 1) [IsFiniteKernel κ] [IsFiniteKernel η] :
     condHellingerDiv a κ η μ ≠ ⊤
       ↔ (∀ᵐ x ∂μ, Integrable (fun b ↦ hellingerFun a ((∂κ x/∂η x) b).toReal) (η x))
         ∧ Integrable (fun x ↦ (hellingerDiv a (κ x) (η x)).toReal) μ := by
-  simp only [condHellingerDiv_ne_top_iff, ha.not_lt, false_implies, true_and]
+  simp only [condHellingerDiv_ne_top_iff, ha.not_le, false_implies, true_and]
+
+lemma condHellingerDiv_eq_top_iff_of_lt_one' (ha_pos : 0 < a) (ha : a < 1)
+    [IsFiniteMeasure μ] [IsFiniteKernel κ] [IsFiniteKernel η] :
+    condHellingerDiv a κ η μ = ⊤
+      ↔ ¬ Integrable (fun x ↦ ∫ b, ((∂κ x/∂η x) b).toReal ^ a ∂η x) μ := by
+  simp_rw [condHellingerDiv_eq_top_iff_of_lt_one ha,
+    (eventually_of_forall <| fun _ ↦ integrable_hellingerFun_rnDeriv_of_lt_one ha_pos.le ha),
+    integrable_hellingerDiv_iff'_of_lt_one ha_pos ha, not_true, false_or]
+
+lemma condHellingerDiv_ne_top_iff_of_lt_one (ha_pos : 0 < a) (ha : a < 1)
+    [IsFiniteMeasure μ] [IsFiniteKernel κ] [IsFiniteKernel η] :
+    condHellingerDiv a κ η μ ≠ ⊤ ↔ Integrable (fun x ↦ ∫ b, ((∂κ x/∂η x) b).toReal ^ a ∂η x) μ := by
+  rw [ne_eq, condHellingerDiv_eq_top_iff_of_lt_one' ha_pos ha, not_not]
+
+lemma condHellingerDiv_eq_integral_iff_ne_top (ha_pos : 0 < a) (ha_ne_one : a ≠ 1)
+    [IsFiniteMeasure μ] [IsFiniteKernel κ] [IsFiniteKernel η] :
+    condHellingerDiv a κ η μ ≠ ⊤
+      ↔ condHellingerDiv a κ η μ = ∫ x, (hellingerDiv a (κ x) (η x)).toReal ∂μ := by
+  refine ⟨fun h ↦ ?_, fun h ↦ h ▸ EReal.coe_ne_top _⟩
+  rw [condHellingerDiv_ne_top_iff' ha_pos ha_ne_one] at h
+  exact condHellingerDiv_of_ae_integrable_of_ae_ac_of_integrable' ha_pos ha_ne_one h.1 h.2.1 h.2.2
+
+lemma condHellingerDiv_eq_integral_iff_of_one_lt (ha : 1 < a) [IsFiniteMeasure μ]
+    [IsFiniteKernel κ] [IsFiniteKernel η] :
+    condHellingerDiv a κ η μ = ∫ x, (hellingerDiv a (κ x) (η x)).toReal ∂μ
+      ↔ (∀ᵐ x ∂μ, Integrable (fun b ↦ hellingerFun a ((∂κ x/∂η x) b).toReal) (η x))
+        ∧ (∀ᵐ x ∂μ, (κ x) ≪ (η x))
+        ∧ Integrable (fun x ↦ ∫ b, ((∂κ x/∂η x) b).toReal ^ a ∂η x) μ :=
+  (condHellingerDiv_eq_integral_iff_ne_top (zero_lt_one.trans ha) ha.ne.symm).symm.trans
+    (condHellingerDiv_ne_top_iff_of_one_lt ha)
+
+lemma condHellingerDiv_eq_integral_iff_of_lt_one (ha_pos : 0 < a) (ha : a < 1)
+    [IsFiniteMeasure μ] [IsFiniteKernel κ] [IsFiniteKernel η] :
+    condHellingerDiv a κ η μ = ∫ x, (hellingerDiv a (κ x) (η x)).toReal ∂μ
+      ↔ Integrable (fun x ↦ ∫ b, ((∂κ x/∂η x) b).toReal ^ a ∂η x) μ :=
+  (condHellingerDiv_eq_integral_iff_ne_top ha_pos ha.ne).symm.trans
+    (condHellingerDiv_ne_top_iff_of_lt_one ha_pos ha)
+
+lemma condHellingerDiv_eq_integral'_of_one_lt (ha_ne_zero : a ≠ 0) (ha : 1 < a) [IsFiniteMeasure μ]
+    [IsFiniteKernel κ] [IsFiniteKernel η]
+    (h_int : ∀ᵐ x ∂μ, Integrable (fun b ↦ hellingerFun a ((∂κ x/∂η x) b).toReal) (η x))
+    (h_ac : ∀ᵐ x ∂μ, (κ x) ≪ (η x))
+    (h_int' : Integrable (fun x ↦ ∫ b, ((∂κ x/∂η x) b).toReal ^ a ∂η x) μ) :
+    condHellingerDiv a κ η μ = (a - 1)⁻¹ * ∫ x, ∫ b, ((∂κ x/∂η x) b).toReal ^ a ∂η x ∂μ
+      - (a - 1)⁻¹ * ((μ ⊗ₘ η) Set.univ).toReal := by
+  rw [condHellingerDiv_eq_integral_iff_of_one_lt ha |>.mpr ⟨h_int, h_ac, h_int'⟩]
+  norm_cast
+  calc
+    _ = ∫ x, ((a - 1)⁻¹ * ∫ b, ((∂κ x/∂η x) b).toReal ^ a ∂η x
+        - (a - 1)⁻¹ * ((η x) Set.univ).toEReal).toReal ∂μ := by
+      apply integral_congr_ae
+      filter_upwards [h_int, h_ac] with x hx_int hx_ac
+      congr
+      exact hellingerDiv_eq_integral_of_ne_top' ha_ne_zero ha.ne.symm <|
+        hellingerDiv_ne_top_iff_of_one_le ha.le _ _ |>.mpr ⟨hx_int, hx_ac⟩
+    _ = ∫ x, ((a - 1)⁻¹ * ∫ b, ((∂κ x/∂η x) b).toReal ^ a ∂η x
+        - (a - 1)⁻¹ * ((η x) Set.univ).toReal) ∂μ := by
+      refine integral_congr_ae (eventually_of_forall fun x ↦ ?_)
+      dsimp
+      rw [EReal.toReal_sub (ne_of_beq_false (by rfl)) (ne_of_beq_false (by rfl))]
+      congr
+      rw [EReal.toReal_mul, EReal.toReal_coe, EReal.toReal_coe_ennreal]
+      all_goals
+        simp only [ne_eq, EReal.mul_eq_top, EReal.mul_eq_bot, EReal.coe_ne_bot, false_and,
+          EReal.coe_neg', EReal.coe_ennreal_ne_bot, and_false, EReal.coe_ne_top,
+          EReal.coe_ennreal_pos, Measure.measure_univ_pos, EReal.coe_pos,
+          EReal.coe_ennreal_eq_top_iff, measure_ne_top, or_self, not_false_eq_true]
+    _ = ∫ x, ((a - 1)⁻¹ * ∫ b, ((∂κ x/∂η x) b).toReal ^ a ∂η x) ∂μ
+        - ∫ x, ((a - 1)⁻¹ * ((η x) Set.univ).toReal) ∂μ :=
+      integral_sub (Integrable.const_mul h_int' _)
+        (Integrable.const_mul (Integrable.kernel _ MeasurableSet.univ) _)
+    _ = _ := by
+      rw [integral_mul_left, integral_mul_left, compProd_univ_toReal]
+
+lemma condHellingerDiv_eq_integral'_of_one_lt' (ha_ne_zero : a ≠ 0) (ha : 1 < a) [IsFiniteMeasure μ]
+    [IsFiniteKernel κ] [IsMarkovKernel η]
+    (h_int : ∀ᵐ x ∂μ, Integrable (fun b ↦ hellingerFun a ((∂κ x/∂η x) b).toReal) (η x))
+    (h_ac : ∀ᵐ x ∂μ, (κ x) ≪ (η x))
+    (h_int' : Integrable (fun x ↦ ∫ b, ((∂κ x/∂η x) b).toReal ^ a ∂η x) μ) :
+    condHellingerDiv a κ η μ = (a - 1)⁻¹ * ∫ x, ∫ b, ((∂κ x/∂η x) b).toReal ^ a ∂η x ∂μ
+      - (a - 1)⁻¹ * (μ Set.univ).toReal := by
+  simp_rw [condHellingerDiv_eq_integral'_of_one_lt ha_ne_zero ha h_int h_ac h_int',
+    compProd_univ_toReal, measure_univ, ENNReal.one_toReal, integral_const, smul_eq_mul, mul_one]
+
+lemma condHellingerDiv_eq_integral'_of_one_lt'' (ha_ne_zero : a ≠ 0) (ha : 1 < a)
+    [IsProbabilityMeasure μ] [IsFiniteKernel κ] [IsMarkovKernel η]
+    (h_int : ∀ᵐ x ∂μ, Integrable (fun b ↦ hellingerFun a ((∂κ x/∂η x) b).toReal) (η x))
+    (h_ac : ∀ᵐ x ∂μ, (κ x) ≪ (η x))
+    (h_int' : Integrable (fun x ↦ ∫ b, ((∂κ x/∂η x) b).toReal ^ a ∂η x) μ) :
+    condHellingerDiv a κ η μ = (a - 1)⁻¹ * ∫ x, ∫ b, ((∂κ x/∂η x) b).toReal ^ a ∂η x ∂μ
+      - (a - 1)⁻¹ := by
+  rw [condHellingerDiv_eq_integral'_of_one_lt' ha_ne_zero ha h_int h_ac h_int', measure_univ,
+    ENNReal.one_toReal, EReal.coe_one, mul_one]
+
+lemma condHellingerDiv_eq_integral'_of_lt_one (ha_pos : 0 < a) (ha : a < 1) [IsFiniteMeasure μ]
+    [IsFiniteKernel κ] [IsFiniteKernel η]
+    (h_int' : Integrable (fun x ↦ ∫ b, ((∂κ x/∂η x) b).toReal ^ a ∂η x) μ) :
+    condHellingerDiv a κ η μ = (a - 1)⁻¹ * ∫ x, ∫ b, ((∂κ x/∂η x) b).toReal ^ a ∂η x ∂μ
+      - (a - 1)⁻¹ * ((μ ⊗ₘ η) Set.univ).toReal := by
+  rw [condHellingerDiv_eq_integral_iff_of_lt_one ha_pos ha |>.mpr h_int']
+  norm_cast
+  calc
+    _ = ∫ x, ((a - 1)⁻¹ * ∫ b, ((∂κ x/∂η x) b).toReal ^ a ∂η x
+        - (a - 1)⁻¹ * ((η x) Set.univ).toEReal).toReal ∂μ := by
+      apply integral_congr_ae
+      filter_upwards with x
+      congr
+      exact hellingerDiv_eq_integral_of_lt_one' ha_pos ha _ _
+    _ = ∫ x, ((a - 1)⁻¹ * ∫ b, ((∂κ x/∂η x) b).toReal ^ a ∂η x --from here to the end the proof is the same as the one of `condHellingerDiv_eq_integral'_of_one_lt`, consider separating this part as a lemma
+        - (a - 1)⁻¹ * ((η x) Set.univ).toReal) ∂μ := by
+      refine integral_congr_ae (eventually_of_forall fun x ↦ ?_)
+      dsimp
+      rw [EReal.toReal_sub (ne_of_beq_false (by rfl)) (ne_of_beq_false (by rfl))]
+      congr
+      rw [EReal.toReal_mul, EReal.toReal_coe, EReal.toReal_coe_ennreal]
+      all_goals
+        simp only [ne_eq, EReal.mul_eq_top, EReal.mul_eq_bot, EReal.coe_ne_bot, false_and,
+          EReal.coe_neg', EReal.coe_ennreal_ne_bot, and_false, EReal.coe_ne_top,
+          EReal.coe_ennreal_pos, Measure.measure_univ_pos, EReal.coe_pos,
+          EReal.coe_ennreal_eq_top_iff, measure_ne_top, or_self, not_false_eq_true]
+    _ = ∫ x, ((a - 1)⁻¹ * ∫ b, ((∂κ x/∂η x) b).toReal ^ a ∂η x) ∂μ
+        - ∫ x, ((a - 1)⁻¹ * ((η x) Set.univ).toReal) ∂μ :=
+      integral_sub (Integrable.const_mul h_int' _)
+        (Integrable.const_mul (Integrable.kernel _ MeasurableSet.univ) _)
+    _ = _ := by
+      rw [integral_mul_left, integral_mul_left, compProd_univ_toReal]
+
+lemma condHellingerDiv_eq_integral'_of_lt_one' (ha_pos : 0 < a) (ha : a < 1) [IsFiniteMeasure μ]
+    [IsFiniteKernel κ] [IsMarkovKernel η]
+    (h_int' : Integrable (fun x ↦ ∫ b, ((∂κ x/∂η x) b).toReal ^ a ∂η x) μ) :
+    condHellingerDiv a κ η μ = (a - 1)⁻¹ * ∫ x, ∫ b, ((∂κ x/∂η x) b).toReal ^ a ∂η x ∂μ
+      - (a - 1)⁻¹ * (μ Set.univ).toReal := by
+  simp_rw [condHellingerDiv_eq_integral'_of_lt_one ha_pos ha h_int', compProd_univ_toReal,
+    measure_univ, ENNReal.one_toReal, integral_const, smul_eq_mul, mul_one]
+
+lemma condHellingerDiv_eq_integral'_of_lt_one'' (ha_pos : 0 < a) (ha : a < 1)
+    [IsProbabilityMeasure μ] [IsFiniteKernel κ] [IsMarkovKernel η]
+    (h_int' : Integrable (fun x ↦ ∫ b, ((∂κ x/∂η x) b).toReal ^ a ∂η x) μ) :
+    condHellingerDiv a κ η μ = (a - 1)⁻¹ * ∫ x, ∫ b, ((∂κ x/∂η x) b).toReal ^ a ∂η x ∂μ
+      - (a - 1)⁻¹ := by
+  rw [condHellingerDiv_eq_integral'_of_lt_one' ha_pos ha h_int', measure_univ,
+    ENNReal.one_toReal, EReal.coe_one, mul_one]
 
 end CondHellingerEq
+
+lemma hellingerDiv_compProd_left [MeasurableSpace.CountableOrCountablyGenerated α β]
+    (ha_nonneg : 0 ≤ a) (μ : Measure α) [IsFiniteMeasure μ] (κ η : kernel α β) [IsFiniteKernel κ]
+    [∀ x, NeZero (κ x)] [IsFiniteKernel η] :
+    hellingerDiv a (μ ⊗ₘ κ) (μ ⊗ₘ η) = condHellingerDiv a κ η μ := by
+  rw [hellingerDiv, condHellingerDiv, fDiv_compProd_left _ _ _
+    (stronglyMeasurable_hellingerFun ha_nonneg) (convexOn_hellingerFun ha_nonneg)]
 
 end Conditional
 

--- a/TestingLowerBounds/Hellinger.lean
+++ b/TestingLowerBounds/Hellinger.lean
@@ -175,7 +175,7 @@ lemma convexOn_hellingerFun (ha_pos : 0 ≤ a) : ConvexOn ℝ (Set.Ici 0) (helli
   · have : hellingerFun a = - (fun x ↦ (1 - a)⁻¹ • (x ^ a - 1)) := by
       ext x
       simp only [Pi.neg_apply]
-      rw [hellingerFun_ne_zero_ne_one ha_pos.ne' ha.ne, smul_eq_mul, ← neg_mul, neg_inv, neg_sub]
+      rw [hellingerFun_of_ne_zero_of_ne_one ha_pos.ne' ha.ne, smul_eq_mul, ← neg_mul, neg_inv, neg_sub]
     rw [this]
     refine ConcaveOn.neg ?_
     exact ((Real.concaveOn_rpow ha_pos.le ha.le).sub (convexOn_const _ (convex_Ici 0))).smul
@@ -223,7 +223,7 @@ lemma integrable_hellingerFun_iff_integrable_rpow (ha_one : a ≠ 1) [IsFiniteMe
     . apply integrableOn_const.mpr
       right
       exact measure_lt_top ν _
-  rw [hellingerFun_ne_zero_ne_one ha_zero ha_one, integrable_const_mul_iff]
+  rw [hellingerFun_of_ne_zero_of_ne_one ha_zero ha_one, integrable_const_mul_iff]
   swap; · simp [sub_eq_zero, ha_one]
   simp_rw [sub_eq_add_neg, integrable_add_const_iff]
 
@@ -415,7 +415,7 @@ lemma hellingerDiv_eq_integral_of_ne_top' (ha_ne_zero : a ≠ 0) (ha_ne_one : a 
     [IsFiniteMeasure μ] [IsFiniteMeasure ν] (h : hellingerDiv a μ ν ≠ ⊤) :
     hellingerDiv a μ ν = (a - 1)⁻¹ * ∫ x, ((∂μ/∂ν) x).toReal ^ a ∂ν - (a - 1)⁻¹ * ν Set.univ := by
   rw [hellingerDiv_eq_integral_of_ne_top h]
-  simp_rw [hellingerFun_ne_zero_ne_one ha_ne_zero ha_ne_one, integral_mul_left]
+  simp_rw [hellingerFun_of_ne_zero_of_ne_one ha_ne_zero ha_ne_one, integral_mul_left]
   rw [integral_sub _ (integrable_const _),
     integral_const, smul_eq_mul, mul_one, mul_sub, EReal.coe_sub, EReal.coe_mul, EReal.coe_mul,
     EReal.coe_ennreal_toReal (measure_ne_top _ _)]
@@ -460,7 +460,7 @@ lemma hellingerDiv_le_of_lt_one (ha_nonneg : 0 ≤ a) (ha : a < 1) (μ ν : Meas
   refine (fDiv_le_zero_add_top (stronglyMeasurable_hellingerFun ha_nonneg)
     (convexOn_hellingerFun ha_nonneg)).trans_eq ?_
   rw [derivAtTop_hellingerFun_of_lt_one ha, zero_mul, add_zero,
-    hellingerFun_ne_zero_ne_one h_zero ha.ne]
+    hellingerFun_of_ne_zero_of_ne_one h_zero ha.ne]
   simp only [zero_sub, mul_neg, mul_one, zero_mul, add_zero, zero_rpow h_zero]
   rw [neg_inv, neg_sub]
 

--- a/TestingLowerBounds/Hellinger.lean
+++ b/TestingLowerBounds/Hellinger.lean
@@ -611,7 +611,7 @@ lemma integrable_hellingerDiv_iff'_of_lt_one (ha_pos : 0 < a) (ha : a < 1) [IsFi
   integrable_hellingerDiv_iff' ha_pos ha.ne (eventually_of_forall
     (fun _ ↦ integrable_hellingerFun_rnDeriv_of_lt_one ha_pos.le ha)) (not_le_of_gt ha).elim
 
-/-- Conditional Hellinger divergence of order `a`. Meaningful for `a ∈ (0, 1) ∪ (1, ∞)`. -/
+/-- Conditional Hellinger divergence of order `a`. -/
 noncomputable def condHellingerDiv (a : ℝ) (κ η : kernel α β) (μ : Measure α) : EReal :=
   condFDiv (hellingerFun a) κ η μ
 

--- a/TestingLowerBounds/Hellinger.lean
+++ b/TestingLowerBounds/Hellinger.lean
@@ -909,7 +909,9 @@ lemma condHellingerDiv_eq_integral'_of_lt_one (ha_pos : 0 < a) (ha : a < 1) [IsF
       filter_upwards with x
       congr
       exact hellingerDiv_eq_integral_of_lt_one' ha_pos ha _ _
-    _ = ∫ x, ((a - 1)⁻¹ * ∫ b, ((∂κ x/∂η x) b).toReal ^ a ∂η x --from here to the end the proof is the same as the one of `condHellingerDiv_eq_integral'_of_one_lt`, consider separating this part as a lemma
+    --from here to the end the proof is the same as the one of
+    --`condHellingerDiv_eq_integral'_of_one_lt`, consider separating this part as a lemma
+    _ = ∫ x, ((a - 1)⁻¹ * ∫ b, ((∂κ x/∂η x) b).toReal ^ a ∂η x
         - (a - 1)⁻¹ * ((η x) Set.univ).toReal) ∂μ := by
       refine integral_congr_ae (eventually_of_forall fun x ↦ ?_)
       dsimp

--- a/TestingLowerBounds/Renyi.lean
+++ b/TestingLowerBounds/Renyi.lean
@@ -51,7 +51,12 @@ lemma exp_mul_llr' [SigmaFinite μ] [SigmaFinite ν] (hμν : μ ≪ ν) :
   have h_pos : 0 < ((∂μ/∂ν) x).toReal :=  ENNReal.toReal_pos hx_pos.ne' hx_lt_top.ne
   rw [← log_rpow h_pos, exp_log (rpow_pos_of_pos h_pos _)]
 
-/-- Rényi divergence of order `a`.-/
+/-- Rényi divergence of order `a`. If `a = 1`, it is defined as `kl μ ν`, otherwise as
+`(a - 1)⁻¹ * log (ν(α) + (a - 1) * Hₐ(μ, ν))`.
+If `ν` is a probability measure then this becomes the more usual definition
+`(a - 1)⁻¹ * log (1 + (a - 1) * Hₐ(μ, ν))`, but this definition maintains some useful properties
+also for a general finite measure `ν`, in particular the integral form
+`Rₐ(μ, ν) = (a - 1)⁻¹ * log (∫ x, ((∂μ/∂ν) x).toReal ^ a ∂ν)`. -/
 noncomputable def renyiDiv (a : ℝ) (μ ν : Measure α) : EReal :=
   if a = 1 then kl μ ν
   else if hellingerDiv a μ ν ≠ ⊤

--- a/TestingLowerBounds/Renyi.lean
+++ b/TestingLowerBounds/Renyi.lean
@@ -334,12 +334,9 @@ section Conditional
 
 variable {β γ : Type*} {mβ : MeasurableSpace β} {mγ : MeasurableSpace γ} {κ η : kernel α β}
 
---TODO: what convention should we adopt for the names of the variables? we cannot use `a` for the element of `α`, so we cannot adopt the same convention as for kl, on the other hand using `x`for the element of `α` may be confusing and we may need `x` for other cases, such that an element of the product space, or some other mute variable. Shall we change the convention for the parameter then? in this case a possibilty would be `λ`. but it is problematic because of the lambda calculus notation, so could we call the parameter `l`? For now I leave it as `x` but I think we should change it at some point.
 
-/--
-Rényi divergence between two kernels κ and η conditional to a measure μ.
-It is defined as `Rₐ(κ, η | μ) := Rₐ(μ ⊗ₘ κ, μ ⊗ₘ η)`.
--/
+/-- Rényi divergence between two kernels κ and η conditional to a measure μ.
+It is defined as `Rₐ(κ, η | μ) := Rₐ(μ ⊗ₘ κ, μ ⊗ₘ η)`. -/
 noncomputable
 def condRenyiDiv (a : ℝ) (κ η : kernel α β) (μ : Measure α) : EReal :=
   renyiDiv a (μ ⊗ₘ κ) (μ ⊗ₘ η)
@@ -430,15 +427,13 @@ lemma condRenyiDiv_of_not_integrable [CountableOrCountablyGenerated α β] (ha_n
     exfalso
     exact h_int this.2
   · rw [condRenyiDiv_eq_top_iff_of_one_le (le_of_not_lt ha)]
-    right; left
-    exact h_int
+    exact Or.inr (Or.inl h_int)
 
 lemma condRenyiDiv_of_one_le_of_not_ac [CountableOrCountablyGenerated α β] (ha : 1 ≤ a)
     [IsFiniteKernel κ] [IsFiniteKernel η] [IsFiniteMeasure μ] (h_ac : ¬ ∀ᵐ x ∂μ, κ x ≪ η x) :
     condRenyiDiv a κ η μ = ⊤ := by
   rw [condRenyiDiv_eq_top_iff_of_one_le ha]
-  right; right
-  exact h_ac
+  exact Or.inr (Or.inr h_ac)
 
 lemma condRenyiDiv_of_lt_one [CountableOrCountablyGenerated α β] (ha_nonneg : 0 ≤ a)
     (ha_lt_one : a < 1) (κ η : kernel α β) (μ : Measure α) [IsFiniteKernel κ] [∀ x, NeZero (κ x)]

--- a/TestingLowerBounds/Renyi.lean
+++ b/TestingLowerBounds/Renyi.lean
@@ -186,7 +186,7 @@ lemma renyiDiv_eq_log_integral (ha_pos : 0 < a) (ha : a < 1)
 with respect to `ν`.
 If `a < 1`, use `renyiDiv_eq_log_integral` instead. -/
 lemma renyiDiv_eq_log_integral_of_ne_top (ha_pos : 0 < a) (ha_ne_one : a ≠ 1) [IsFiniteMeasure μ]
-    [IsProbabilityMeasure ν] (h : renyiDiv a μ ν ≠ ⊤) :
+    [IsFiniteMeasure ν] (h : renyiDiv a μ ν ≠ ⊤) :
     renyiDiv a μ ν = (a - 1)⁻¹ * log (∫ x, ((∂μ/∂ν) x).toReal ^ a ∂ν) := by
   cases lt_or_gt_of_ne ha_ne_one with
   | inl ha => exact renyiDiv_eq_log_integral ha_pos ha
@@ -196,17 +196,17 @@ lemma renyiDiv_eq_log_integral_of_ne_top (ha_pos : 0 < a) (ha_ne_one : a ≠ 1) 
     rw [renyiDiv_ne_top_iff_of_one_le ha.le] at h
     rw [renyiDiv_of_one_lt_of_integrable_of_ac ha h.1 h.2]
     congr
-    rw [hellingerDiv_eq_integral_of_ne_top'' ha_pos.ne' ha_ne_one h_ne_top]
+    rw [hellingerDiv_eq_integral_of_ne_top' ha_pos.ne' ha_ne_one h_ne_top]
     rw [EReal.toReal_sub, EReal.toReal_mul, EReal.toReal_coe, EReal.toReal_coe, mul_sub, ← mul_assoc,
-      mul_inv_cancel, one_mul]
+      mul_inv_cancel, one_mul, EReal.toReal_mul, EReal.toReal_coe, ← mul_assoc, mul_inv_cancel (by linarith), one_mul]
     · simp
     · linarith
     · rw [← EReal.coe_mul]
       exact EReal.coe_ne_top _
     · rw [← EReal.coe_mul]
       exact EReal.coe_ne_bot _
-    · exact EReal.coe_ne_top _
-    · exact EReal.coe_ne_bot _
+    · simp [measure_ne_top, EReal.mul_eq_top]
+    · simp [measure_ne_top, EReal.mul_eq_bot]
 
 /-- If `μ ≪ ν`, the Rényi divergence `renyiDiv a μ ν` can be written as the log of an integral
 with respect to `μ`. -/
@@ -224,7 +224,7 @@ lemma renyiDiv_eq_log_integral' (ha_pos : 0 < a) (ha : a < 1) [IsFiniteMeasure �
 with respect to `μ`.
 If `a < 1`, use `renyiDiv_eq_log_integral'` instead. -/
 lemma renyiDiv_eq_log_integral_of_ne_top' (ha_pos : 0 < a) (ha : a ≠ 1) [IsFiniteMeasure μ]
-    [IsProbabilityMeasure ν] (hμν : μ ≪ ν) (h : renyiDiv a μ ν ≠ ⊤) :
+    [IsFiniteMeasure ν] (hμν : μ ≪ ν) (h : renyiDiv a μ ν ≠ ⊤) :
     renyiDiv a μ ν = (a - 1)⁻¹ * log (∫ x, ((∂μ/∂ν) x).toReal ^ (a - 1) ∂μ) := by
   rw [renyiDiv_eq_log_integral_of_ne_top ha_pos ha, integral_rpow_rnDeriv ha_pos ha]
   congr 3
@@ -269,7 +269,7 @@ lemma renyiDiv_symm (ha_pos : 0 < a) (ha : a < 1)
 
 -- todo: `ν ≪ μ` is necessary (?) due to the llr being 0 when `(∂μ/∂ν) x = 0`.
 -- In that case, `exp (llr μ ν x) = 1 ≠ 0 = (∂μ/∂ν) x`.
-lemma coe_cgf_llr (ha_pos : 0 < a) (ha : a < 1) [IsFiniteMeasure μ] [IsProbabilityMeasure ν]
+lemma coe_cgf_llr (ha_pos : 0 < a) (ha : a < 1) [IsFiniteMeasure μ] [IsFiniteMeasure ν]
     (hνμ : ν ≪ μ) :
     cgf (llr μ ν) ν a = (a - 1) * renyiDiv a μ ν := by
   rw [renyiDiv_eq_log_integral ha_pos ha, ← mul_assoc]
@@ -281,14 +281,14 @@ lemma coe_cgf_llr (ha_pos : 0 < a) (ha : a < 1) [IsFiniteMeasure μ] [IsProbabil
   congr 2
   exact integral_congr_ae (exp_mul_llr hνμ)
 
-lemma cgf_llr (ha_pos : 0 < a) (ha : a < 1) [IsFiniteMeasure μ] [IsProbabilityMeasure ν]
+lemma cgf_llr (ha_pos : 0 < a) (ha : a < 1) [IsFiniteMeasure μ] [IsFiniteMeasure ν]
     (hνμ : ν ≪ μ) :
     cgf (llr μ ν) ν a = (a - 1) * (renyiDiv a μ ν).toReal := by
   have : (a - 1) * (renyiDiv a μ ν).toReal = ((a - 1) * renyiDiv a μ ν).toReal := by
     rw [EReal.toReal_mul, ← EReal.coe_one, ← EReal.coe_sub, EReal.toReal_coe]
   rw [this, ← coe_cgf_llr ha_pos ha hνμ, EReal.toReal_coe]
 
-lemma coe_cgf_llr' (ha_pos : 0 < a) [IsFiniteMeasure μ] [IsProbabilityMeasure ν]
+lemma coe_cgf_llr' (ha_pos : 0 < a) [IsFiniteMeasure μ] [IsFiniteMeasure ν]
     (h : renyiDiv (1 + a) μ ν ≠ ⊤) :
     cgf (llr μ ν) μ a = a * renyiDiv (1 + a) μ ν := by
   have hμν : μ ≪ ν := by
@@ -308,7 +308,7 @@ lemma coe_cgf_llr' (ha_pos : 0 < a) [IsFiniteMeasure μ] [IsProbabilityMeasure �
   congr 2
   exact integral_congr_ae (exp_mul_llr' hμν)
 
-lemma cgf_llr' (ha_pos : 0 < a) [IsFiniteMeasure μ] [IsProbabilityMeasure ν]
+lemma cgf_llr' (ha_pos : 0 < a) [IsFiniteMeasure μ] [IsFiniteMeasure ν]
     (h : renyiDiv (1 + a) μ ν ≠ ⊤) :
     cgf (llr μ ν) μ a = a * (renyiDiv (1 + a) μ ν).toReal := by
   have : a * (renyiDiv (1 + a) μ ν).toReal = (a * renyiDiv (1 + a) μ ν).toReal := by

--- a/TestingLowerBounds/Renyi.lean
+++ b/TestingLowerBounds/Renyi.lean
@@ -341,7 +341,8 @@ noncomputable
 def condRenyiDiv (a : ℝ) (κ η : kernel α β) (μ : Measure α) : EReal :=
   renyiDiv a (μ ⊗ₘ κ) (μ ⊗ₘ η)
 
---Maybe this can be stated in a nicer way, but I didn't find a way to do it. It's probably good enough to use `condRenyiDiv_of_lt_one`.
+/-Maybe this can be stated in a nicer way, but I didn't find a way to do it. It's probably good
+enough to use `condRenyiDiv_of_lt_one`.-/
 lemma condRenyiDiv_zero (κ η : kernel α β) (μ : Measure α) [IsFiniteMeasure μ]
     [IsFiniteKernel κ] [IsFiniteKernel η] :
     condRenyiDiv 0 κ η μ = - log ((μ ⊗ₘ η) {x | 0 < (∂μ ⊗ₘ κ/∂μ ⊗ₘ η) x}).toReal := by

--- a/TestingLowerBounds/Renyi.lean
+++ b/TestingLowerBounds/Renyi.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2024 Rémy Degenne. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Rémy Degenne
+Authors: Rémy Degenne, Lorenzo Luccioli
 -/
 import TestingLowerBounds.KullbackLeibler
 import TestingLowerBounds.Hellinger
@@ -53,97 +53,119 @@ lemma exp_mul_llr' [SigmaFinite μ] [SigmaFinite ν] (hμν : μ ≪ ν) :
 
 /-- Rényi divergence of order `a`.-/
 noncomputable def renyiDiv (a : ℝ) (μ ν : Measure α) : EReal :=
-  if a = 0 then - log (ν {x | 0 < (∂μ/∂ν) x}).toReal
-  else if a = 1 then kl μ ν
+  if a = 1 then kl μ ν
   else if hellingerDiv a μ ν ≠ ⊤
-    then (a - 1)⁻¹ * log (1 + (a - 1) * (hellingerDiv a μ ν).toReal)
+    then (a - 1)⁻¹ * log ((ν Set.univ).toReal + (a - 1) * (hellingerDiv a μ ν).toReal)
     else ⊤
 
 @[simp]
-lemma renyiDiv_zero (μ ν : Measure α) :
-    renyiDiv 0 μ ν = - log (ν {x | 0 < (∂μ/∂ν) x}).toReal := if_pos rfl
+lemma renyiDiv_zero (μ ν : Measure α) [SigmaFinite μ] [IsFiniteMeasure ν] :
+    renyiDiv 0 μ ν = - log (ν {x | 0 < (∂μ/∂ν) x}).toReal := by
+  rw [renyiDiv, if_neg zero_ne_one, if_pos]
+  swap
+  · rw [hellingerDiv_zero, ne_eq, EReal.coe_ennreal_eq_top_iff]
+    exact measure_ne_top ν _
+  simp [ne_eq, zero_sub, ← neg_inv, inv_one, EReal.coe_neg, EReal.coe_one, neg_mul, one_mul, ←
+    sub_eq_add_neg, ite_not]
+  rw [hellingerDiv_zero_toReal]
+  norm_num
 
 @[simp]
 lemma renyiDiv_one (μ ν : Measure α) : renyiDiv 1 μ ν = kl μ ν := by
-  rw [renyiDiv, if_neg (by simp), if_pos rfl]
+  rw [renyiDiv, if_pos rfl]
 
 section TopAndBounds
 
-lemma renyiDiv_eq_top_iff_hellingerDiv_eq_top (ha_pos : 0 < a) (ha_ne_one : a ≠ 1) :
+lemma renyiDiv_eq_top_iff_hellingerDiv_eq_top' (ha_ne_one : a ≠ 1) :
     renyiDiv a μ ν = ⊤ ↔ hellingerDiv a μ ν = ⊤ := by
-  simp only [renyiDiv, ha_pos.ne', ↓reduceIte, ha_ne_one, ne_eq, ite_not, ite_eq_left_iff]
+  simp only [renyiDiv, ha_ne_one, ↓reduceIte, ne_eq, ite_not, ite_eq_left_iff]
   rw [← EReal.coe_mul]
   simp only [EReal.coe_ne_top, imp_false, not_not]
 
-lemma renyiDiv_eq_top_iff_of_one_lt (ha : 1 < a) (μ ν : Measure α)
+lemma renyiDiv_eq_top_iff_hellingerDiv_eq_top [SigmaFinite μ] [SigmaFinite ν] :
+    renyiDiv a μ ν = ⊤ ↔ hellingerDiv a μ ν = ⊤ := by
+  by_cases ha : a = 1
+  · rw [ha, renyiDiv_one, hellingerDiv_one]
+  · exact renyiDiv_eq_top_iff_hellingerDiv_eq_top' ha
+
+lemma renyiDiv_eq_top_iff_of_one_le (ha : 1 ≤ a) (μ ν : Measure α)
     [IsFiniteMeasure μ] [SigmaFinite ν] :
     renyiDiv a μ ν = ⊤
       ↔ ¬ Integrable (fun x ↦ hellingerFun a ((∂μ/∂ν) x).toReal) ν ∨ ¬ μ ≪ ν := by
-  rw [renyiDiv_eq_top_iff_hellingerDiv_eq_top (zero_lt_one.trans ha) ha.ne',
-    hellingerDiv_eq_top_iff_of_one_lt ha]
+  rw [renyiDiv_eq_top_iff_hellingerDiv_eq_top, hellingerDiv_eq_top_iff_of_one_le ha]
 
-lemma renyiDiv_ne_top_iff_of_one_lt (ha : 1 < a) (μ ν : Measure α)
+lemma renyiDiv_ne_top_iff_of_one_le (ha : 1 ≤ a) (μ ν : Measure α)
     [IsFiniteMeasure μ] [SigmaFinite ν] :
     renyiDiv a μ ν ≠ ⊤
       ↔ Integrable (fun x ↦ hellingerFun a ((∂μ/∂ν) x).toReal) ν ∧ μ ≪ ν := by
-  rw [ne_eq, renyiDiv_eq_top_iff_hellingerDiv_eq_top (zero_lt_one.trans ha) ha.ne',
-    hellingerDiv_eq_top_iff_of_one_lt ha]
+  rw [ne_eq, renyiDiv_eq_top_iff_hellingerDiv_eq_top, hellingerDiv_eq_top_iff_of_one_le ha]
   push_neg
   rfl
 
-lemma renyiDiv_eq_top_iff_of_lt_one (ha_pos : 0 < a) (ha : a < 1) (μ ν : Measure α)
+lemma renyiDiv_eq_top_iff_of_lt_one (ha : a < 1) (μ ν : Measure α)
     [IsFiniteMeasure μ] [SigmaFinite ν] :
     renyiDiv a μ ν = ⊤ ↔ ¬ Integrable (fun x ↦ hellingerFun a ((∂μ/∂ν) x).toReal) ν := by
-  rw [renyiDiv_eq_top_iff_hellingerDiv_eq_top ha_pos ha.ne,
-    hellingerDiv_eq_top_iff_of_le_one ha.le]
+  rw [renyiDiv_eq_top_iff_hellingerDiv_eq_top, hellingerDiv_eq_top_iff_of_lt_one ha]
 
-lemma renyiDiv_ne_top_iff_of_lt_one (ha_pos : 0 < a) (ha : a < 1) (μ ν : Measure α)
+lemma renyiDiv_ne_top_iff_of_lt_one (ha : a < 1) (μ ν : Measure α)
     [IsFiniteMeasure μ] [SigmaFinite ν] :
     renyiDiv a μ ν ≠ ⊤ ↔ Integrable (fun x ↦ hellingerFun a ((∂μ/∂ν) x).toReal) ν := by
-  rw [ne_eq, renyiDiv_eq_top_iff_hellingerDiv_eq_top ha_pos ha.ne,
-    hellingerDiv_eq_top_iff_of_le_one ha.le]
+  rw [ne_eq, renyiDiv_eq_top_iff_hellingerDiv_eq_top, hellingerDiv_eq_top_iff_of_lt_one ha]
   push_neg
   rfl
 
-lemma renyiDiv_ne_top_of_lt_one (ha_pos : 0 < a) (ha : a < 1) (μ ν : Measure α)
+lemma renyiDiv_ne_top_of_lt_one (ha_nonneg : 0 ≤ a) (ha : a < 1) (μ ν : Measure α)
     [IsFiniteMeasure μ] [IsFiniteMeasure ν] :
     renyiDiv a μ ν ≠ ⊤ := by
-  rw [ne_eq, renyiDiv_eq_top_iff_hellingerDiv_eq_top ha_pos ha.ne]
-  exact hellingerDiv_ne_top_of_le_one ha_pos ha.le _ _
+  rw [ne_eq, renyiDiv_eq_top_iff_hellingerDiv_eq_top]
+  exact hellingerDiv_ne_top_of_lt_one ha_nonneg ha _ _
 
-lemma renyiDiv_of_not_integrable (ha_pos : 0 < a) (ha_ne_one : a ≠ 1)
+lemma renyiDiv_of_not_integrable' (ha_ne_one : a ≠ 1)
     (h_int : ¬ Integrable (fun x ↦ hellingerFun a ((∂μ/∂ν) x).toReal) ν) :
     renyiDiv a μ ν = ⊤ := by
-  rw [renyiDiv_eq_top_iff_hellingerDiv_eq_top ha_pos ha_ne_one]
+  rw [renyiDiv_eq_top_iff_hellingerDiv_eq_top' ha_ne_one]
   by_contra h
   exact h (hellingerDiv_of_not_integrable h_int)
 
-lemma renyiDiv_of_lt_one' [IsFiniteMeasure μ] [SigmaFinite ν]
-    (ha_pos : 0 < a) (ha_lt_one : a < 1)
-    (h_int : Integrable (fun x ↦ hellingerFun a ((∂μ/∂ν) x).toReal) ν) :
-    renyiDiv a μ ν = (a - 1)⁻¹ * log (1 + (a - 1) * (hellingerDiv a μ ν).toReal) := by
-  rw [renyiDiv, if_neg ha_pos.ne', if_neg ha_lt_one.ne,
-    if_pos ((hellingerDiv_ne_top_iff_of_le_one ha_lt_one.le _ _).mpr h_int)]
-
-lemma renyiDiv_of_lt_one (μ ν : Measure α) [IsFiniteMeasure μ] [IsFiniteMeasure ν]
-    (ha_pos : 0 < a) (ha_lt_one : a < 1) :
-    renyiDiv a μ ν = (a - 1)⁻¹ * log (1 + (a - 1) * (hellingerDiv a μ ν).toReal) := by
-  rw [renyiDiv_of_lt_one' ha_pos ha_lt_one]
-  exact integrable_hellingerFun_rnDeriv_of_le_one ha_pos ha_lt_one.le
-
-lemma renyiDiv_of_one_lt_of_ac [IsFiniteMeasure μ] [SigmaFinite ν] (ha_one_lt : 1 < a)
-    (h_int : Integrable (fun x ↦ hellingerFun a ((∂μ/∂ν) x).toReal) ν) (hμν : μ ≪ ν) :
-    renyiDiv a μ ν = (a - 1)⁻¹ * log (1 + (a - 1) * (hellingerDiv a μ ν).toReal) := by
-  rw [renyiDiv, if_neg (zero_lt_one.trans ha_one_lt).ne', if_neg ha_one_lt.ne',
-    if_pos ((hellingerDiv_ne_top_iff_of_one_lt ha_one_lt _ _).mpr ⟨h_int, hμν⟩)]
-
-lemma renyiDiv_of_one_lt_of_not_ac [IsFiniteMeasure μ] [SigmaFinite ν]
-    (ha_one_lt : 1 < a) (hμν : ¬ μ ≪ ν) :
+lemma renyiDiv_of_not_integrable [IsFiniteMeasure μ] [SigmaFinite ν]
+    (h_int : ¬ Integrable (fun x ↦ hellingerFun a ((∂μ/∂ν) x).toReal) ν) :
     renyiDiv a μ ν = ⊤ := by
-  rw [renyiDiv, if_neg (zero_lt_one.trans ha_one_lt).ne', if_neg ha_one_lt.ne', if_neg]
-  rw [hellingerDiv_ne_top_iff_of_one_lt ha_one_lt]
+  rw [renyiDiv_eq_top_iff_hellingerDiv_eq_top]
+  by_contra h
+  exact h (hellingerDiv_of_not_integrable h_int)
+
+lemma renyiDiv_of_one_le_of_not_ac (ha : 1 ≤ a) (hμν : ¬ μ ≪ ν)
+    [SigmaFinite μ] [SigmaFinite ν] :
+    renyiDiv a μ ν = ⊤ := by
+  by_cases ha_one : a = 1
+  · rw [ha_one, renyiDiv_one]
+    exact kl_of_not_ac hμν
+  replace ha : 1 < a := lt_of_le_of_ne ha fun h ↦ ha_one h.symm
+  rw [renyiDiv, if_neg ha.ne', if_neg]
+  rw [hellingerDiv_ne_top_iff_of_one_le ha.le]
   push_neg
   exact fun _ ↦ hμν
+
+lemma renyiDiv_of_lt_one' (ha_lt_one : a < 1) [IsFiniteMeasure μ] [SigmaFinite ν]
+    (h_int : Integrable (fun x ↦ hellingerFun a ((∂μ/∂ν) x).toReal) ν) :
+    renyiDiv a μ ν
+      = (a - 1)⁻¹ * log ((ν Set.univ).toReal + (a - 1) * (hellingerDiv a μ ν).toReal) := by
+  rw [renyiDiv, if_neg ha_lt_one.ne,
+    if_pos ((hellingerDiv_ne_top_iff_of_lt_one ha_lt_one _ _).mpr h_int)]
+
+lemma renyiDiv_of_lt_one (ha_nonneg : 0 ≤ a) (ha_lt_one : a < 1) (μ ν : Measure α)
+    [IsFiniteMeasure μ] [IsFiniteMeasure ν] :
+    renyiDiv a μ ν
+      = (a - 1)⁻¹ * log ((ν Set.univ).toReal + (a - 1) * (hellingerDiv a μ ν).toReal) := by
+  rw [renyiDiv_of_lt_one' ha_lt_one]
+  exact integrable_hellingerFun_rnDeriv_of_lt_one ha_nonneg ha_lt_one
+
+lemma renyiDiv_of_one_lt_of_integrable_of_ac (ha_one_lt : 1 < a) [IsFiniteMeasure μ] [SigmaFinite ν]
+    (h_int : Integrable (fun x ↦ hellingerFun a ((∂μ/∂ν) x).toReal) ν) (hμν : μ ≪ ν) :
+    renyiDiv a μ ν
+      = (a - 1)⁻¹ * log ((ν Set.univ).toReal + (a - 1) * (hellingerDiv a μ ν).toReal) := by
+  rw [renyiDiv, if_neg ha_one_lt.ne',
+    if_pos ((hellingerDiv_ne_top_iff_of_one_le ha_one_lt.le _ _).mpr ⟨h_int, hμν⟩)]
 
 end TopAndBounds
 
@@ -151,39 +173,30 @@ section IntegralForm
 
 /-- The Rényi divergence `renyiDiv a μ ν` can be written as the log of an integral
 with respect to `ν`. -/
-lemma renyiDiv_eq_log_integral [IsFiniteMeasure μ] [IsProbabilityMeasure ν]
-    (ha_pos : 0 < a) (ha : a < 1) :
+lemma renyiDiv_eq_log_integral (ha_pos : 0 < a) (ha : a < 1)
+    [IsFiniteMeasure μ] [IsFiniteMeasure ν] :
     renyiDiv a μ ν = (a - 1)⁻¹ * log (∫ x, ((∂μ/∂ν) x).toReal ^ a ∂ν) := by
-  rw [renyiDiv_of_lt_one μ ν ha_pos ha]
+  rw [renyiDiv_of_lt_one ha_pos.le ha μ ν]
   congr
-  rw [hellingerDiv_eq_integral_of_lt_one' ha_pos ha]
-  simp only [measure_univ, EReal.coe_ennreal_one, mul_one]
-  rw [EReal.toReal_sub, EReal.toReal_mul, EReal.toReal_coe, EReal.toReal_coe, mul_sub, ← mul_assoc,
-    mul_inv_cancel, one_mul]
-  · simp
-  · linarith
-  · rw [← EReal.coe_mul]
-    exact EReal.coe_ne_top _
-  · rw [← EReal.coe_mul]
-    exact EReal.coe_ne_bot _
-  · exact EReal.coe_ne_top _
-  · exact EReal.coe_ne_bot _
+  simp_rw [hellingerDiv_toReal_of_lt_one ha_pos ha, mul_sub, ← mul_assoc,
+    mul_inv_cancel (sub_neg.mpr ha).ne, one_mul]
+  norm_num
 
 /-- The Rényi divergence `renyiDiv a μ ν` can be written as the log of an integral
 with respect to `ν`.
 If `a < 1`, use `renyiDiv_eq_log_integral` instead. -/
-lemma renyiDiv_eq_log_integral_of_ne_top [IsFiniteMeasure μ] [IsProbabilityMeasure ν]
-    (ha_pos : 0 < a) (ha : a ≠ 1) (h : renyiDiv a μ ν ≠ ⊤) :
+lemma renyiDiv_eq_log_integral_of_ne_top (ha_pos : 0 < a) (ha_ne_one : a ≠ 1) [IsFiniteMeasure μ]
+    [IsProbabilityMeasure ν] (h : renyiDiv a μ ν ≠ ⊤) :
     renyiDiv a μ ν = (a - 1)⁻¹ * log (∫ x, ((∂μ/∂ν) x).toReal ^ a ∂ν) := by
-  cases lt_or_gt_of_ne ha with
+  cases lt_or_gt_of_ne ha_ne_one with
   | inl ha => exact renyiDiv_eq_log_integral ha_pos ha
   | inr ha =>
     have h_ne_top : hellingerDiv a μ ν ≠ ⊤ := by
-      rwa [ne_eq, ← renyiDiv_eq_top_iff_hellingerDiv_eq_top ha_pos ha.ne']
-    rw [renyiDiv_ne_top_iff_of_one_lt ha] at h
-    rw [renyiDiv_of_one_lt_of_ac ha h.1 h.2]
+      rwa [ne_eq, ← renyiDiv_eq_top_iff_hellingerDiv_eq_top]
+    rw [renyiDiv_ne_top_iff_of_one_le ha.le] at h
+    rw [renyiDiv_of_one_lt_of_integrable_of_ac ha h.1 h.2]
     congr
-    rw [hellingerDiv_eq_integral_of_ne_top'' ha.ne' h_ne_top]
+    rw [hellingerDiv_eq_integral_of_ne_top'' ha_pos.ne' ha_ne_one h_ne_top]
     rw [EReal.toReal_sub, EReal.toReal_mul, EReal.toReal_coe, EReal.toReal_coe, mul_sub, ← mul_assoc,
       mul_inv_cancel, one_mul]
     · simp
@@ -197,8 +210,8 @@ lemma renyiDiv_eq_log_integral_of_ne_top [IsFiniteMeasure μ] [IsProbabilityMeas
 
 /-- If `μ ≪ ν`, the Rényi divergence `renyiDiv a μ ν` can be written as the log of an integral
 with respect to `μ`. -/
-lemma renyiDiv_eq_log_integral' [IsFiniteMeasure μ] [IsProbabilityMeasure ν]
-    (ha_pos : 0 < a) (ha : a < 1) (hμν : μ ≪ ν) :
+lemma renyiDiv_eq_log_integral' (ha_pos : 0 < a) (ha : a < 1) [IsFiniteMeasure μ]
+    [IsProbabilityMeasure ν] (hμν : μ ≪ ν) :
     renyiDiv a μ ν = (a - 1)⁻¹ * log (∫ x, ((∂μ/∂ν) x).toReal ^ (a - 1) ∂μ) := by
   rw [renyiDiv_eq_log_integral ha_pos ha, integral_rpow_rnDeriv ha_pos ha.ne]
   congr 3
@@ -210,8 +223,8 @@ lemma renyiDiv_eq_log_integral' [IsFiniteMeasure μ] [IsProbabilityMeasure ν]
 /-- If `μ ≪ ν`, the Rényi divergence `renyiDiv a μ ν` can be written as the log of an integral
 with respect to `μ`.
 If `a < 1`, use `renyiDiv_eq_log_integral'` instead. -/
-lemma renyiDiv_eq_log_integral_of_ne_top' [IsFiniteMeasure μ] [IsProbabilityMeasure ν]
-    (ha_pos : 0 < a) (ha : a ≠ 1) (hμν : μ ≪ ν) (h : renyiDiv a μ ν ≠ ⊤) :
+lemma renyiDiv_eq_log_integral_of_ne_top' (ha_pos : 0 < a) (ha : a ≠ 1) [IsFiniteMeasure μ]
+    [IsProbabilityMeasure ν] (hμν : μ ≪ ν) (h : renyiDiv a μ ν ≠ ⊤) :
     renyiDiv a μ ν = (a - 1)⁻¹ * log (∫ x, ((∂μ/∂ν) x).toReal ^ (a - 1) ∂μ) := by
   rw [renyiDiv_eq_log_integral_of_ne_top ha_pos ha, integral_rpow_rnDeriv ha_pos ha]
   congr 3
@@ -226,7 +239,7 @@ end IntegralForm
 lemma renyiDiv_symm' (ha_pos : 0 < a) (ha : a < 1) (h_eq : μ Set.univ = ν Set.univ)
     [IsFiniteMeasure μ] [IsFiniteMeasure ν] :
     (1 - a) * renyiDiv a μ ν = a * renyiDiv (1 - a) ν μ := by
-  rw [renyiDiv_of_lt_one _ _ ha_pos ha, renyiDiv_of_lt_one _ _]
+  rw [renyiDiv_of_lt_one ha_pos.le ha, renyiDiv_of_lt_one _ _]
   rotate_left
   · linarith
   · linarith
@@ -241,22 +254,23 @@ lemma renyiDiv_symm' (ha_pos : 0 < a) (ha : a < 1) (h_eq : μ Set.univ = ν Set.
     · linarith
   rw [this, ← EReal.coe_mul, inv_neg, mul_neg, mul_inv_cancel ha_pos.ne']
   simp only [EReal.coe_neg, EReal.coe_one, one_mul]
-  congr
+  congr 5
+  · exact h_eq.symm
   rw [← EReal.toReal_coe a, ← EReal.toReal_mul, EReal.toReal_coe a, ← h, EReal.toReal_mul,
     ← neg_mul]
-  congr
+  congr 1
   norm_cast
   rw [EReal.toReal_coe, neg_sub]
 
-lemma renyiDiv_symm [IsProbabilityMeasure μ] [IsProbabilityMeasure ν]
-    (ha_pos : 0 < a) (ha : a < 1) :
+lemma renyiDiv_symm (ha_pos : 0 < a) (ha : a < 1)
+    [IsProbabilityMeasure μ] [IsProbabilityMeasure ν] :
     (1 - a) * renyiDiv a μ ν = a * renyiDiv (1 - a) ν μ :=
   renyiDiv_symm' ha_pos ha (by simp)
 
 -- todo: `ν ≪ μ` is necessary (?) due to the llr being 0 when `(∂μ/∂ν) x = 0`.
 -- In that case, `exp (llr μ ν x) = 1 ≠ 0 = (∂μ/∂ν) x`.
-lemma coe_cgf_llr [IsFiniteMeasure μ] [IsProbabilityMeasure ν] (hνμ : ν ≪ μ)
-    (ha_pos : 0 < a) (ha : a < 1) :
+lemma coe_cgf_llr (ha_pos : 0 < a) (ha : a < 1) [IsFiniteMeasure μ] [IsProbabilityMeasure ν]
+    (hνμ : ν ≪ μ) :
     cgf (llr μ ν) ν a = (a - 1) * renyiDiv a μ ν := by
   rw [renyiDiv_eq_log_integral ha_pos ha, ← mul_assoc]
   have : ((a : EReal) - 1) * ↑(a - 1)⁻¹ = 1 := by
@@ -267,18 +281,18 @@ lemma coe_cgf_llr [IsFiniteMeasure μ] [IsProbabilityMeasure ν] (hνμ : ν ≪
   congr 2
   exact integral_congr_ae (exp_mul_llr hνμ)
 
-lemma cgf_llr [IsFiniteMeasure μ] [IsProbabilityMeasure ν] (hνμ : ν ≪ μ)
-    (ha_pos : 0 < a) (ha : a < 1) :
+lemma cgf_llr (ha_pos : 0 < a) (ha : a < 1) [IsFiniteMeasure μ] [IsProbabilityMeasure ν]
+    (hνμ : ν ≪ μ) :
     cgf (llr μ ν) ν a = (a - 1) * (renyiDiv a μ ν).toReal := by
   have : (a - 1) * (renyiDiv a μ ν).toReal = ((a - 1) * renyiDiv a μ ν).toReal := by
     rw [EReal.toReal_mul, ← EReal.coe_one, ← EReal.coe_sub, EReal.toReal_coe]
-  rw [this, ← coe_cgf_llr hνμ ha_pos ha, EReal.toReal_coe]
+  rw [this, ← coe_cgf_llr ha_pos ha hνμ, EReal.toReal_coe]
 
-lemma coe_cgf_llr' [IsFiniteMeasure μ] [IsProbabilityMeasure ν]
-    (ha_pos : 0 < a) (h : renyiDiv (1 + a) μ ν ≠ ⊤) :
+lemma coe_cgf_llr' (ha_pos : 0 < a) [IsFiniteMeasure μ] [IsProbabilityMeasure ν]
+    (h : renyiDiv (1 + a) μ ν ≠ ⊤) :
     cgf (llr μ ν) μ a = a * renyiDiv (1 + a) μ ν := by
   have hμν : μ ≪ ν := by
-    rw [renyiDiv_ne_top_iff_of_one_lt] at h
+    rw [renyiDiv_ne_top_iff_of_one_le] at h
     · exact h.2
     · linarith
   rw [renyiDiv_eq_log_integral_of_ne_top' _ _ hμν h, ← mul_assoc]
@@ -294,8 +308,8 @@ lemma coe_cgf_llr' [IsFiniteMeasure μ] [IsProbabilityMeasure ν]
   congr 2
   exact integral_congr_ae (exp_mul_llr' hμν)
 
-lemma cgf_llr' [IsFiniteMeasure μ] [IsProbabilityMeasure ν]
-    (ha_pos : 0 < a) (h : renyiDiv (1 + a) μ ν ≠ ⊤) :
+lemma cgf_llr' (ha_pos : 0 < a) [IsFiniteMeasure μ] [IsProbabilityMeasure ν]
+    (h : renyiDiv (1 + a) μ ν ≠ ⊤) :
     cgf (llr μ ν) μ a = a * (renyiDiv (1 + a) μ ν).toReal := by
   have : a * (renyiDiv (1 + a) μ ν).toReal = (a * renyiDiv (1 + a) μ ν).toReal := by
     rw [EReal.toReal_mul, EReal.toReal_coe]
@@ -315,5 +329,144 @@ def renyiMeasure (a : ℝ) (μ ν : Measure α) : Measure α :=
   (μ + ν).withDensity (renyiDensity a μ ν)
 
 end RenyiMeasure
+
+section Conditional
+
+variable {β γ : Type*} {mβ : MeasurableSpace β} {mγ : MeasurableSpace γ} {κ η : kernel α β}
+
+--TODO: what convention should we adopt for the names of the variables? we cannot use `a` for the element of `α`, so we cannot adopt the same convention as for kl, on the other hand using `x`for the element of `α` may be confusing and we may need `x` for other cases, such that an element of the product space, or some other mute variable. Shall we change the convention for the parameter then? in this case a possibilty would be `λ`. but it is problematic because of the lambda calculus notation, so could we call the parameter `l`? For now I leave it as `x` but I think we should change it at some point.
+
+/--
+Rényi divergence between two kernels κ and η conditional to a measure μ.
+It is defined as `Rₐ(κ, η | μ) := Rₐ(μ ⊗ₘ κ, μ ⊗ₘ η)`.
+-/
+noncomputable
+def condRenyiDiv (a : ℝ) (κ η : kernel α β) (μ : Measure α) : EReal :=
+  renyiDiv a (μ ⊗ₘ κ) (μ ⊗ₘ η)
+
+--Maybe this can be stated in a nicer way, but I didn't find a way to do it. It's probably good enough to use `condRenyiDiv_of_lt_one`.
+lemma condRenyiDiv_zero (κ η : kernel α β) (μ : Measure α) [IsFiniteMeasure μ]
+    [IsFiniteKernel κ] [IsFiniteKernel η] :
+    condRenyiDiv 0 κ η μ = - log ((μ ⊗ₘ η) {x | 0 < (∂μ ⊗ₘ κ/∂μ ⊗ₘ η) x}).toReal := by
+  rw [condRenyiDiv, renyiDiv_zero]
+
+@[simp]
+lemma condRenyiDiv_one [CountableOrCountablyGenerated α β] (κ η : kernel α β) (μ : Measure α)
+    [IsMarkovKernel κ] [IsFiniteKernel η] [IsFiniteMeasure μ] :
+    condRenyiDiv 1 κ η μ = condKL κ η μ := by
+  rw [condRenyiDiv, renyiDiv_one, kl_compProd_left]
+
+section TopAndBounds
+
+lemma condRenyiDiv_eq_top_iff_of_one_le [CountableOrCountablyGenerated α β] (ha : 1 ≤ a)
+    (κ η : kernel α β) (μ : Measure α) [IsFiniteKernel κ] [IsFiniteKernel η] [IsFiniteMeasure μ] :
+    condRenyiDiv a κ η μ = ⊤
+      ↔ ¬ (∀ᵐ x ∂μ, Integrable (fun b ↦ hellingerFun a ((∂κ x/∂η x) b).toReal) (η x))
+        ∨ ¬Integrable (fun x ↦ ∫ (b : β), hellingerFun a ((∂κ x/∂η x) b).toReal ∂η x) μ
+        ∨ ¬ ∀ᵐ x ∂μ, κ x ≪ η x := by
+  rw [condRenyiDiv, renyiDiv_eq_top_iff_of_one_le ha,
+    kernel.Measure.absolutelyContinuous_compProd_right_iff, integrable_f_rnDeriv_compProd_right_iff
+      (stronglyMeasurable_hellingerFun (by linarith)) (convexOn_hellingerFun (by linarith))]
+  tauto
+
+lemma condRenyiDiv_ne_top_iff_of_one_le [CountableOrCountablyGenerated α β] (ha : 1 ≤ a)
+    (κ η : kernel α β) (μ : Measure α) [IsFiniteKernel κ] [IsFiniteKernel η] [IsFiniteMeasure μ] :
+    condRenyiDiv a κ η μ ≠ ⊤
+      ↔ (∀ᵐ x ∂μ, Integrable (fun b ↦ hellingerFun a ((∂κ x/∂η x) b).toReal) (η x))
+        ∧ Integrable (fun x ↦ ∫ (b : β), hellingerFun a ((∂κ x/∂η x) b).toReal ∂η x) μ
+        ∧ ∀ᵐ x ∂μ, κ x ≪ η x := by
+  rw [ne_eq, condRenyiDiv_eq_top_iff_of_one_le ha]
+  push_neg
+  rfl
+
+lemma condRenyiDiv_eq_top_iff_of_lt_one [CountableOrCountablyGenerated α β] (ha_nonneg : 0 ≤ a)
+    (ha : a < 1) (κ η : kernel α β) (μ : Measure α)
+    [IsFiniteKernel κ] [IsFiniteKernel η] [IsFiniteMeasure μ] :
+    condRenyiDiv a κ η μ = ⊤
+    ↔ ¬ (∀ᵐ x ∂μ, Integrable (fun b ↦ hellingerFun a ((∂κ x/∂η x) b).toReal) (η x))
+      ∨ ¬Integrable (fun x ↦ ∫ (b : β), hellingerFun a ((∂κ x/∂η x) b).toReal ∂η x) μ := by
+  rw [condRenyiDiv, renyiDiv_eq_top_iff_of_lt_one ha, integrable_f_rnDeriv_compProd_right_iff
+      (stronglyMeasurable_hellingerFun (by linarith)) (convexOn_hellingerFun (by linarith))]
+  tauto
+
+lemma condRenyiDiv_ne_top_iff_of_lt_one [CountableOrCountablyGenerated α β] (ha_nonneg : 0 ≤ a)
+    (ha : a < 1) (κ η : kernel α β) (μ : Measure α)
+    [IsFiniteKernel κ] [IsFiniteKernel η] [IsFiniteMeasure μ] :
+    condRenyiDiv a κ η μ ≠ ⊤
+    ↔ (∀ᵐ x ∂μ, Integrable (fun b ↦ hellingerFun a ((∂κ x/∂η x) b).toReal) (η x))
+      ∧ Integrable (fun x ↦ ∫ (b : β), hellingerFun a ((∂κ x/∂η x) b).toReal ∂η x) μ := by
+  rw [ne_eq, condRenyiDiv_eq_top_iff_of_lt_one ha_nonneg ha]
+  push_neg
+  rfl
+
+lemma condRenyiDiv_ne_top_of_lt_one (ha_nonneg : 0 ≤ a) (ha : a < 1) (κ η : kernel α β)
+    (μ : Measure α) [IsFiniteKernel κ] [IsFiniteKernel η] [IsFiniteMeasure μ] :
+    condRenyiDiv a κ η μ ≠ ⊤ := by
+  rw [condRenyiDiv, ne_eq, renyiDiv_eq_top_iff_hellingerDiv_eq_top]
+  exact hellingerDiv_ne_top_of_lt_one ha_nonneg ha _ _
+
+lemma condRenyiDiv_of_not_ae_integrable [CountableOrCountablyGenerated α β] (ha_nonneg : 0 ≤ a)
+    [IsFiniteKernel κ] [IsFiniteKernel η] [IsFiniteMeasure μ]
+    (h_int : ¬ (∀ᵐ x ∂μ, Integrable (fun b ↦ hellingerFun a ((∂κ x/∂η x) b).toReal) (η x))) :
+    condRenyiDiv a κ η μ = ⊤ := by
+  by_cases ha : a < 1
+  · have := integrable_hellingerFun_rnDeriv_of_lt_one ha_nonneg ha (μ := μ ⊗ₘ κ) (ν := μ ⊗ₘ η)
+    rw [integrable_f_rnDeriv_compProd_right_iff
+      (stronglyMeasurable_hellingerFun (by linarith)) (convexOn_hellingerFun (by linarith))] at this
+    exfalso
+    exact h_int this.1
+  · rw [condRenyiDiv_eq_top_iff_of_one_le (le_of_not_lt ha)]
+    left
+    exact h_int
+
+lemma condRenyiDiv_of_not_integrable [CountableOrCountablyGenerated α β] (ha_nonneg : 0 ≤ a)
+    [IsFiniteKernel κ] [IsFiniteKernel η] [IsFiniteMeasure μ]
+    (h_int : ¬Integrable (fun x ↦ ∫ (b : β), hellingerFun a ((∂κ x/∂η x) b).toReal ∂η x) μ) :
+    condRenyiDiv a κ η μ = ⊤ := by
+  by_cases ha : a < 1
+  · have := integrable_hellingerFun_rnDeriv_of_lt_one ha_nonneg ha (μ := μ ⊗ₘ κ) (ν := μ ⊗ₘ η)
+    rw [integrable_f_rnDeriv_compProd_right_iff
+      (stronglyMeasurable_hellingerFun (by linarith)) (convexOn_hellingerFun (by linarith))] at this
+    exfalso
+    exact h_int this.2
+  · rw [condRenyiDiv_eq_top_iff_of_one_le (le_of_not_lt ha)]
+    right; left
+    exact h_int
+
+lemma condRenyiDiv_of_one_le_of_not_ac [CountableOrCountablyGenerated α β] (ha : 1 ≤ a)
+    [IsFiniteKernel κ] [IsFiniteKernel η] [IsFiniteMeasure μ] (h_ac : ¬ ∀ᵐ x ∂μ, κ x ≪ η x) :
+    condRenyiDiv a κ η μ = ⊤ := by
+  rw [condRenyiDiv_eq_top_iff_of_one_le ha]
+  right; right
+  exact h_ac
+
+lemma condRenyiDiv_of_lt_one [CountableOrCountablyGenerated α β] (ha_nonneg : 0 ≤ a)
+    (ha_lt_one : a < 1) (κ η : kernel α β) (μ : Measure α) [IsFiniteKernel κ] [∀ x, NeZero (κ x)]
+    [IsFiniteKernel η] [IsFiniteMeasure μ] :
+    condRenyiDiv a κ η μ = (a - 1)⁻¹
+      * log (((μ ⊗ₘ η) Set.univ).toReal + (a - 1) * (condHellingerDiv a κ η μ).toReal) := by
+  rw [condRenyiDiv, renyiDiv_of_lt_one ha_nonneg ha_lt_one, hellingerDiv_compProd_left ha_nonneg _]
+
+lemma condRenyiDiv_of_one_lt_of_ac [CountableOrCountablyGenerated α β] (ha_one_lt : 1 < a)
+    (κ η : kernel α β) (μ : Measure α) [IsFiniteKernel κ] [∀ x, NeZero (κ x)]
+    [IsFiniteKernel η] [IsFiniteMeasure μ]
+    (h_int : ∀ᵐ x ∂μ, Integrable (fun b ↦ hellingerFun a ((∂κ x/∂η x) b).toReal) (η x))
+    (h_ac : ∀ᵐ x ∂μ, (κ x) ≪ (η x))
+    (h_int' : Integrable (fun x ↦ ∫ b, ((∂κ x/∂η x) b).toReal ^ a ∂η x) μ) :
+    condRenyiDiv a κ η μ = (a - 1)⁻¹
+      * log (((μ ⊗ₘ η) Set.univ).toReal + (a - 1) * (condHellingerDiv a κ η μ).toReal) := by
+  have ha_pos : 0 < a := by linarith
+  rw [condRenyiDiv, renyiDiv_of_one_lt_of_integrable_of_ac ha_one_lt _ _,
+    hellingerDiv_compProd_left ha_pos.le _]
+  · refine (integrable_f_rnDeriv_compProd_right_iff (stronglyMeasurable_hellingerFun ha_pos.le)
+      (convexOn_hellingerFun ha_pos.le)).mpr ⟨h_int, ?_⟩
+    apply (integrable_hellingerDiv_iff h_int fun _ ↦ h_ac).mp
+    exact (integrable_hellingerDiv_iff' ha_pos ha_one_lt.ne' h_int fun _ ↦ h_ac).mpr h_int'
+  · exact kernel.Measure.absolutelyContinuous_compProd_iff.mpr ⟨fun _ a ↦ a, h_ac⟩
+
+end TopAndBounds
+
+
+end Conditional
 
 end ProbabilityTheory

--- a/TestingLowerBounds/Testing/RenyiChangeMeasure.lean
+++ b/TestingLowerBounds/Testing/RenyiChangeMeasure.lean
@@ -29,7 +29,7 @@ namespace ProbabilityTheory
 
 variable {α : Type*} {mα : MeasurableSpace α} {μ ν ν' : Measure α} {s : Set α}
 
-lemma measure_llr_gt_renyiDiv_le_exp [IsFiniteMeasure μ] [IsProbabilityMeasure ν]
+lemma measure_llr_gt_renyiDiv_le_exp [IsFiniteMeasure μ] [IsFiniteMeasure ν]
     {a : ℝ} (ha : 0 < a) (c : ℝ) (h : renyiDiv (1 + a) μ ν ≠ ⊤) :
     (μ {x | EReal.toReal (renyiDiv (1 + a) μ ν) + c < llr μ ν x}).toReal ≤ exp (-a * c) := by
   have hμν : μ ≪ ν := by
@@ -54,7 +54,7 @@ lemma measure_llr_gt_renyiDiv_le_exp [IsFiniteMeasure μ] [IsProbabilityMeasure 
         rw [cgf_llr' ha h]
         ring
 
-lemma measure_sub_le_measure_mul_exp_renyiDiv [IsFiniteMeasure μ] [IsProbabilityMeasure ν]
+lemma measure_sub_le_measure_mul_exp_renyiDiv [IsFiniteMeasure μ] [IsFiniteMeasure ν]
     (s : Set α) {a : ℝ} (ha : 0 < a) (c : ℝ) (h : renyiDiv (1 + a) μ ν ≠ ⊤) :
     (μ s).toReal - exp (- a * c) ≤ (ν s).toReal * exp ((renyiDiv (1 + a) μ ν).toReal + c) := by
   have hμν : μ ≪ ν := by
@@ -66,7 +66,7 @@ lemma measure_sub_le_measure_mul_exp_renyiDiv [IsFiniteMeasure μ] [IsProbabilit
   exact measure_llr_gt_renyiDiv_le_exp ha c h
 
 lemma one_sub_exp_le_add_measure_mul_exp_max_renyiDiv [IsProbabilityMeasure μ]
-    [IsProbabilityMeasure ν] [IsProbabilityMeasure ν'] (s : Set α)
+    [IsFiniteMeasure ν] [IsFiniteMeasure ν'] (s : Set α)
     {a : ℝ} (ha : 0 < a) (c : ℝ)
     (hν : renyiDiv (1 + a) μ ν ≠ ⊤) (hν' : renyiDiv (1 + a) μ ν' ≠ ⊤) :
     1 - 2 * exp (- a * c)
@@ -93,7 +93,7 @@ lemma one_sub_exp_le_add_measure_mul_exp_max_renyiDiv [IsProbabilityMeasure μ]
         rw [max_add_add_right]
 
 lemma exp_neg_max_renyiDiv_le_add_measure [IsProbabilityMeasure μ]
-    [IsProbabilityMeasure ν] [IsProbabilityMeasure ν'] (s : Set α)
+    [IsFiniteMeasure ν] [IsFiniteMeasure ν'] (s : Set α)
     {a : ℝ} (ha : 0 < a) (hν : renyiDiv (1 + a) μ ν ≠ ⊤) (hν' : renyiDiv (1 + a) μ ν' ≠ ⊤) :
     2⁻¹ * exp (- max (renyiDiv (1 + a) μ ν).toReal (renyiDiv (1 + a) μ ν').toReal - log 4 / a)
       ≤ (ν s).toReal + (ν' sᶜ).toReal := by
@@ -105,7 +105,7 @@ lemma exp_neg_max_renyiDiv_le_add_measure [IsProbabilityMeasure μ]
   rw [this] at h
   rwa [neg_sub_left, exp_neg, mul_inv_le_iff' (exp_pos _), add_comm (log 4 / a)]
 
-lemma exp_neg_chernoffDiv_le_add_measure [IsProbabilityMeasure ν] [IsProbabilityMeasure ν']
+lemma exp_neg_chernoffDiv_le_add_measure [IsFiniteMeasure ν] [IsFiniteMeasure ν']
     (s : Set α) {a : ℝ} (ha : 0 < a) (h_ne_top : chernoffDiv (1 + a) ν ν' ≠ ⊤) :
     2⁻¹ * exp (- (chernoffDiv (1 + a) ν ν').toReal - log 4 / a)
       ≤ (ν s).toReal + (ν' sᶜ).toReal := by

--- a/TestingLowerBounds/Testing/RenyiChangeMeasure.lean
+++ b/TestingLowerBounds/Testing/RenyiChangeMeasure.lean
@@ -34,7 +34,7 @@ lemma measure_llr_gt_renyiDiv_le_exp [IsFiniteMeasure μ] [IsProbabilityMeasure 
     (μ {x | EReal.toReal (renyiDiv (1 + a) μ ν) + c < llr μ ν x}).toReal ≤ exp (-a * c) := by
   have hμν : μ ≪ ν := by
     by_contra h_not
-    exact h (renyiDiv_of_one_lt_of_not_ac (by linarith) h_not)
+    exact h (renyiDiv_of_one_le_of_not_ac (by linarith) h_not)
   calc (μ {x | EReal.toReal (renyiDiv (1 + a) μ ν) + c < llr μ ν x}).toReal
   _ ≤ (μ {x | EReal.toReal (renyiDiv (1 + a) μ ν) + c ≤ llr μ ν x}).toReal := by
         refine ENNReal.toReal_mono (measure_ne_top _ _) (measure_mono (fun x ↦ ?_))
@@ -44,7 +44,7 @@ lemma measure_llr_gt_renyiDiv_le_exp [IsFiniteMeasure μ] [IsProbabilityMeasure 
         refine measure_ge_le_exp_cgf (X := llr μ ν) (μ := μ) ((renyiDiv (1 + a) μ ν).toReal + c)
           ha.le ?_
         rw [integrable_congr (exp_mul_llr' hμν)]
-        rw [renyiDiv_ne_top_iff_of_one_lt, integrable_hellingerFun_iff_integrable_rpow] at h
+        rw [renyiDiv_ne_top_iff_of_one_le, integrable_hellingerFun_iff_integrable_rpow] at h
         · rw [integrable_rpow_rnDeriv_iff hμν ha]
           exact h.1
         · linarith
@@ -59,7 +59,7 @@ lemma measure_sub_le_measure_mul_exp_renyiDiv [IsFiniteMeasure μ] [IsProbabilit
     (μ s).toReal - exp (- a * c) ≤ (ν s).toReal * exp ((renyiDiv (1 + a) μ ν).toReal + c) := by
   have hμν : μ ≪ ν := by
     by_contra h_not
-    exact h (renyiDiv_of_one_lt_of_not_ac (by linarith) h_not)
+    exact h (renyiDiv_of_one_le_of_not_ac (by linarith) h_not)
   refine le_trans ?_ (measure_sub_le_measure_mul_exp hμν s ((renyiDiv (1 + a) μ ν).toReal + c)
     (measure_ne_top _ _))
   gcongr
@@ -74,10 +74,10 @@ lemma one_sub_exp_le_add_measure_mul_exp_max_renyiDiv [IsProbabilityMeasure μ]
         * exp (max (renyiDiv (1 + a) μ ν).toReal (renyiDiv (1 + a) μ ν').toReal + c) := by
   have hμν : μ ≪ ν := by
     by_contra h_not
-    exact hν (renyiDiv_of_one_lt_of_not_ac (by linarith) h_not)
+    exact hν (renyiDiv_of_one_le_of_not_ac (by linarith) h_not)
   have hμν' : μ ≪ ν' := by
     by_contra h_not
-    exact hν' (renyiDiv_of_one_lt_of_not_ac (by linarith) h_not)
+    exact hν' (renyiDiv_of_one_le_of_not_ac (by linarith) h_not)
   calc 1 - 2 * exp (- a * c)
   _ = 1 - exp (- a * c) - exp (- a * c) := by ring
   _ ≤ 1 - (μ {x | (renyiDiv (1 + a) μ ν).toReal + c < llr μ ν x}).toReal

--- a/blueprint/src/sections/hellinger_alpha.tex
+++ b/blueprint/src/sections/hellinger_alpha.tex
@@ -5,10 +5,11 @@
   \lean{ProbabilityTheory.hellingerDiv}
   \leanok
   \uses{def:KL, def:fDiv}
-  Let $\mu, \nu$ be two measures on $\mathcal X$. The Hellinger divergence of order $\alpha \in (0,+\infty)$ between $\mu$ and $\nu$ is
+  Let $\mu, \nu$ be two measures on $\mathcal X$. The Hellinger divergence of order $\alpha \in [0,+\infty)$ between $\mu$ and $\nu$ is
   \begin{align*}
   \He_\alpha(\mu, \nu) = \left\{
   \begin{array}{ll}
+    \nu \{x \mid 0 = \frac{d\mu}{d\nu} x\} & \text{for } \alpha = 0 \\
     \KL(\mu, \nu) & \text{for } \alpha = 1
     \\
     D_{f_\alpha}(\mu, \nu) & \text{for } \alpha \in (0,+\infty) \backslash \{1\}
@@ -18,11 +19,11 @@
 \end{definition}
 
 \begin{lemma}
-  \label{lem:hellingerAlpha_ne_top_of_le_one}
-  \lean{ProbabilityTheory.hellingerDiv_ne_top_of_le_one}
+  \label{lem:hellingerAlpha_ne_top_of_lt_one}
+  \lean{ProbabilityTheory.hellingerDiv_ne_top_of_lt_one}
   \leanok
   \uses{def:hellingerAlpha}
-  For $\alpha \in (0, 1)$ and finite measures $\mu, \nu$, $\He_\alpha(\mu, \nu) < \infty$.
+  For $\alpha \in [0, 1)$ and finite measures $\mu, \nu$, $\He_\alpha(\mu, \nu) < \infty$.
 \end{lemma}
 
 \begin{proof}\leanok
@@ -73,7 +74,7 @@
 
 \begin{lemma}
   \label{lem:hellingerAlpha_symm}
-  \lean{ProbabilityTheory.hellingerDiv_symm}
+  \lean{ProbabilityTheory.hellingerDiv_symm'}
   \leanok
   \uses{def:hellingerAlpha}
   For $\alpha \in (0, 1)$ and finite measures $\mu, \nu$ with $\mu(\mathcal X) = \nu(\mathcal X)$, $(1 - \alpha) \He_\alpha(\mu, \nu) = \alpha \He_{1 - \alpha}(\nu, \mu)$.
@@ -90,7 +91,7 @@ Use Lemma~\ref{lem:integral_rpow_rnDeriv}.
   \lean{ProbabilityTheory.condHellingerDiv}
   \leanok
   \uses{def:condFDiv}
-  Let $\mu$ be a measure on $\mathcal X$ and $\kappa, \eta : \mathcal X \rightsquigarrow \mathcal Y$ be two Markov kernels. The conditional Hellinger divergence of order $\alpha \in (0,+\infty) \backslash \{1\}$ between $\kappa$ and $\eta$ conditionally to $\mu$ is
+  Let $\mu$ be a measure on $\mathcal X$ and $\kappa, \eta : \mathcal X \rightsquigarrow \mathcal Y$ be two kernels. The conditional Hellinger divergence of order $\alpha \in (0,+\infty) \backslash \{1\}$ between $\kappa$ and $\eta$ conditionally to $\mu$ is
   \begin{align*}
   \He_\alpha(\kappa, \eta \mid \mu) = D_{f_\alpha}(\kappa, \eta \mid \mu) \: ,
   \end{align*}

--- a/blueprint/src/sections/renyi_divergence.tex
+++ b/blueprint/src/sections/renyi_divergence.tex
@@ -9,8 +9,8 @@
   \begin{align*}
   R_\alpha(\mu, \nu) = \left\{
  \begin{array}{ll}
-  - \log(\nu\{x \mid \frac{d \mu}{d \nu}(x) > 0\}) & \text{for } \alpha = 0
-  \\
+  % - \log(\nu\{x \mid \frac{d \mu}{d \nu}(x) > 0\}) & \text{for } \alpha = 0 --make a lemma for this
+  % \\
   \KL(\mu, \nu) & \text{for } \alpha = 1
   \\
   \frac{1}{\alpha - 1} \log (1 + (\alpha - 1) \He_\alpha(\mu, \nu)) & \text{for } \alpha \in (0,+\infty) \backslash \{1\}
@@ -19,15 +19,28 @@
 \end{definition}
 
 \begin{lemma}
+  \label{lem:renyiDiv_zero}
+  \lean{ProbabilityTheory.renyiDiv_zero}
+  \leanok
+  \uses{def:Renyi}
+  For $\mu$ a sigma finite measure and $\nu$ a finite measure 
+  \[R_0(\mu, \nu) = - \log(\nu\{x \mid \frac{d \mu}{d \nu}(x) > 0\}) \: .\]
+\end{lemma}
+
+\begin{proof}\leanok
+\uses{def:hellingerAlpha}
+\end{proof}
+
+\begin{lemma}
   \label{lem:renyiDiv_ne_top_of_lt_one}
   \lean{ProbabilityTheory.renyiDiv_ne_top_of_lt_one}
   \leanok
   \uses{def:Renyi}
-  For $\alpha \in (0, 1)$ and finite measures $\mu, \nu$, $R_\alpha(\mu, \nu) < \infty$.
+  For $\alpha \in [0, 1)$ and finite measures $\mu, \nu$, $R_\alpha(\mu, \nu) < \infty$.
 \end{lemma}
 
 \begin{proof}\leanok
-\uses{lem:hellingerAlpha_ne_top_of_le_one}
+\uses{lem:hellingerAlpha_ne_top_of_lt_one}
 \end{proof}
 
 \begin{lemma}
@@ -35,7 +48,7 @@
   \lean{ProbabilityTheory.renyiDiv_eq_log_integral_of_ne_top}
   \leanok
   \uses{def:Renyi}
-  For $\alpha \in (0,1)\cup(1, \infty)$, $\mu$ a finite measure and $\nu$ a probability measure, if $R_\alpha(\mu, \nu) < \infty$ then
+  For $\alpha \in (0,1)\cup(1, \infty)$ and finite measures $\mu, \nu$, if $R_\alpha(\mu, \nu) < \infty$ then
   \begin{align*}
   R_\alpha(\mu, \nu) = \frac{1}{\alpha - 1} \log \int_x \left(\frac{d \mu}{d \nu}(x)\right)^\alpha \partial \nu
   \: .
@@ -51,7 +64,7 @@
   \lean{ProbabilityTheory.renyiDiv_eq_log_integral_of_ne_top'}
   \leanok
   \uses{def:Renyi}
-  For $\alpha \in (0,1)\cup(1, \infty)$, $\mu$ a finite measure and $\nu$ a probability measure, if $R_\alpha(\mu, \nu) < \infty$ and $\mu \ll \nu$ then
+  For $\alpha \in (0,1)\cup(1, \infty)$ and finite measures $\mu, \nu$, if $R_\alpha(\mu, \nu) < \infty$ and $\mu \ll \nu$ then
   \begin{align*}
   R_\alpha(\mu, \nu) = \frac{1}{\alpha - 1} \log \int_x \left(\frac{d \mu}{d \nu}(x)\right)^{\alpha - 1} \partial \mu
   \: .
@@ -64,10 +77,11 @@
 
 \begin{lemma}
   \label{lem:renyi_symm}
-  \lean{ProbabilityTheory.renyiDiv_symm}
+  \lean{ProbabilityTheory.renyiDiv_symm'}
   \leanok
   \uses{def:Renyi}
-  For $\alpha \in (0, 1)$ and finite measures $\mu, \nu$ with $\mu(\mathcal X) = \nu(\mathcal X)$, $(1 - \alpha) R_\alpha(\mu, \nu) = \alpha R_{1 - \alpha}(\nu, \mu)$.
+  For $\alpha \in (0, 1)$ and finite measures $\mu, \nu$ with $\mu(\mathcal X) = \nu(\mathcal X)$, 
+  \[(1 - \alpha) R_\alpha(\mu, \nu) = \alpha R_{1 - \alpha}(\nu, \mu) \: .\]
 \end{lemma}
 
 \begin{proof}\leanok
@@ -103,10 +117,10 @@ Unfold the definitions, using Lemma~\ref{lem:renyi_eq_log_integral'} for the Ré
 
 \begin{definition}[Conditional Rényi divergence]
   \label{def:condRenyi}
-  %\lean{}
-  %\leanok
+  \lean{ProbabilityTheory.condRenyiDiv}
+  \leanok
   \uses{def:condHellingerAlpha}
-  Let $\mu$ be a measure on $\mathcal X$ and $\kappa, \eta : \mathcal X \rightsquigarrow \mathcal Y$ be two Markov kernels. The conditional Rényi divergence of order $\alpha \in (0,+\infty) \backslash \{1\}$ between $\kappa$ and $\eta$ conditionally to $\mu$ is
+  Let $\mu$ be a measure on $\mathcal X$ and $\kappa, \eta : \mathcal X \rightsquigarrow \mathcal Y$ be two kernels. The conditional Rényi divergence of order $\alpha \in (0,+\infty) \backslash \{1\}$ between $\kappa$ and $\eta$ conditionally to $\mu$ is
   \begin{align*}
   R_\alpha(\kappa, \eta \mid \mu) =\frac{1}{\alpha - 1} \log (1 + (\alpha - 1) \He_\alpha(\kappa, \eta \mid \mu)) \: .
   \end{align*}

--- a/blueprint/src/sections/renyi_divergence.tex
+++ b/blueprint/src/sections/renyi_divergence.tex
@@ -9,8 +9,6 @@
   \begin{align*}
   R_\alpha(\mu, \nu) = \left\{
  \begin{array}{ll}
-  % - \log(\nu\{x \mid \frac{d \mu}{d \nu}(x) > 0\}) & \text{for } \alpha = 0 --make a lemma for this
-  % \\
   \KL(\mu, \nu) & \text{for } \alpha = 1
   \\
   \frac{1}{\alpha - 1} \log (1 + (\alpha - 1) \He_\alpha(\mu, \nu)) & \text{for } \alpha \in (0,+\infty) \backslash \{1\}
@@ -23,7 +21,7 @@
   \lean{ProbabilityTheory.renyiDiv_zero}
   \leanok
   \uses{def:Renyi}
-  For $\mu$ a sigma finite measure and $\nu$ a finite measure 
+  For $\mu$ a sigma-finite measure and $\nu$ a finite measure 
   \[R_0(\mu, \nu) = - \log(\nu\{x \mid \frac{d \mu}{d \nu}(x) > 0\}) \: .\]
 \end{lemma}
 

--- a/blueprint/src/sections/testing.tex
+++ b/blueprint/src/sections/testing.tex
@@ -195,8 +195,8 @@ Two applications of Lemma~\ref{lem:llr_change_measure}, then sum them and use $\
 
 \begin{lemma}
   \label{lem:change_measure_variance_add}
-  \lean{ProbabilityTheory.one_sub_exp_le_add_measure_mul_exp_max_renyiDiv} %TODO: this seems like a mistake, the lemma doesn't correspond to this statement. Moreover, the referenced lean lemma is already linked to the statement below and it's more similar to that, even if not exactly the same.
-  \leanok
+  % \lean{}
+  % \leanok
   \uses{}
   Let $\mu, \nu, \xi$ be three probability measures on $\mathcal X$ and let $E$ be an event on $\mathcal X$. For $\beta > 0$~,
   \begin{align*}
@@ -205,7 +205,7 @@ Two applications of Lemma~\ref{lem:llr_change_measure}, then sum them and use $\
   \end{align*}
 \end{lemma}
 
-\begin{proof}\leanok
+\begin{proof} %\leanok
 \uses{lem:llr_change_measure_add}
 Use Lemma~\ref{lem:llr_change_measure_add} with the choices $\KL(\xi, \mu) + \sqrt{\beta \Var_{\xi}\left[\log\frac{d\xi}{d\mu}\right]}$ and $\KL(\xi, \nu) + \sqrt{\beta \Var_{\xi}\left[\log\frac{d\xi}{d\nu}\right]}$ for $\beta_1$ and $\beta_2$.
 Then use Chebyshev's inequality to bound the probabilities of deviation of the log-likelihood ratios.

--- a/blueprint/src/sections/testing.tex
+++ b/blueprint/src/sections/testing.tex
@@ -141,7 +141,7 @@ Use Lemma~\ref{lem:llr_change_measure} with the choice $\KL(\mu, \nu) + \sqrt{\V
   \lean{ProbabilityTheory.measure_llr_gt_renyiDiv_le_exp}
   \leanok
   \uses{def:Renyi}
-  For $\mu$ a finite measure, $\nu$ a probability measure and $\alpha, \beta > 0$,
+  For $\mu, \nu$ finite measures and $\alpha, \beta > 0$,
   \begin{align*}
   \mu\left\{ \log\frac{d \mu}{d \nu} > R_{1+\alpha}(\mu, \nu) + \beta \right\}
   \le e^{- \alpha \beta}
@@ -166,7 +166,7 @@ Then $\mu\left[\left(\frac{d \mu}{d \nu}\right)^\alpha \right] = \nu\left[\left(
   \lean{ProbabilityTheory.measure_sub_le_measure_mul_exp_renyiDiv}
   \leanok
   \uses{def:Renyi}
-  Let $\mu, \nu$ be two measures on $\mathcal X$ and let $E$ be an event on $\mathcal X$. Let $\alpha,\beta > 0$. Then
+  Let $\mu, \nu$ be two finite measures on $\mathcal X$ and let $E$ be an event on $\mathcal X$. Let $\alpha,\beta > 0$. Then
   \begin{align*}
   \nu(E) e^{R_{1+\alpha}(\mu, \nu) + \beta} \ge \mu(E) - e^{-\alpha \beta} \: .
   \end{align*}
@@ -195,7 +195,7 @@ Two applications of Lemma~\ref{lem:llr_change_measure}, then sum them and use $\
 
 \begin{lemma}
   \label{lem:change_measure_variance_add}
-  \lean{ProbabilityTheory.one_sub_exp_le_add_measure_mul_exp_max_renyiDiv}
+  \lean{ProbabilityTheory.one_sub_exp_le_add_measure_mul_exp_max_renyiDiv} %TODO: this seems like a mistake, the lemma doesn't correspond to this statement. Moreover, the referenced lean lemma is already linked to the statement below and it's more similar to that, even if not exactly the same.
   \leanok
   \uses{}
   Let $\mu, \nu, \xi$ be three probability measures on $\mathcal X$ and let $E$ be an event on $\mathcal X$. For $\beta > 0$~,


### PR DESCRIPTION
Major changes to the files `Hellinger.lean` and `Renyi.lean`.

In particular:
- Change the definitions of `hellingerFun` and `renyiDiv`
- Fix and expand the API of `hellingerFun`, 
`hellingerDiv`, `condHellingerDiv` and `renyiDiv`
- Add `condRenyiDiv` with some API
- Generalize the hypotheses of some lemmas
- Add comments
