### PR TITLE
Cleanup `KullbackLeibler.lean`

### DIFF
--- a/TestingLowerBounds/ForMathlib/CountableOrCountablyGenerated.lean
+++ b/TestingLowerBounds/ForMathlib/CountableOrCountablyGenerated.lean
@@ -4,11 +4,6 @@ namespace MeasurableSpace
 
 variable {α β γ : Type*} [MeasurableSpace α] [MeasurableSpace β] [MeasurableSpace γ]
 
-/-I'm not sure this is the right way to state those facts, maybe they should just be lemmas?
-I cannot put the Nonempty α as a hypothesis because then α would not be mentioned in the thesis
-and that is not allowed in a typeclass instance. Anyway I feel that in this way they are not very
-useful because it seems that the typeclass inference is not able to use them.-/
---solution: state those as lemmas
 
 lemma countable_left_of_prod_of_nonempty [Nonempty β] (h : Countable (α × β)) : Countable α := by
   contrapose h
@@ -20,7 +15,6 @@ lemma countable_right_of_prod_of_nonempty [Nonempty α] (h : Countable (α × β
   rw [not_countable_iff] at *
   infer_instance
 
---TODO: what name should we use? in this name the first 'left' refers to the fact that we are talking about `α`, which is the left factor in the product, the second 'left' refers to the fact that the product is on the left argument of `CountableOrCountablyGenerated`
 lemma countableOrCountablyGenerated_left_of_prod_left_of_nonempty [Nonempty β]
     [h : CountableOrCountablyGenerated (α × β) γ] :
     CountableOrCountablyGenerated α γ := by
@@ -51,7 +45,6 @@ lemma countablyGenerated_right_of_prod_of_nonempty [Nonempty α] (h : CountablyG
   -- contrapose h
   sorry
 
-
 lemma countableOrCountablyGenerated_right_of_prod_right_of_nonempty [Nonempty β]
     [h : CountableOrCountablyGenerated α (β × γ)] :
     CountableOrCountablyGenerated α γ := by
@@ -67,7 +60,6 @@ lemma countableOrCountablyGenerated_left_of_prod_right_of_nonempty [Nonempty γ]
   · infer_instance
   · have := countablyGenerated_left_of_prod_of_nonempty h
     infer_instance
-
 
 instance [Countable (α × β)] : Countable (β × α) :=
   Countable.of_equiv _ (Equiv.prodComm α β)

--- a/TestingLowerBounds/ForMathlib/CountableOrCountablyGenerated.lean
+++ b/TestingLowerBounds/ForMathlib/CountableOrCountablyGenerated.lean
@@ -1,0 +1,89 @@
+import Mathlib.MeasureTheory.MeasurableSpace.CountablyGenerated
+
+namespace MeasurableSpace
+
+variable {α β γ : Type*} [MeasurableSpace α] [MeasurableSpace β] [MeasurableSpace γ]
+
+/-I'm not sure this is the right way to state those facts, maybe they should just be lemmas?
+I cannot put the Nonempty α as a hypothesis because then α would not be mentioned in the thesis
+and that is not allowed in a typeclass instance. Anyway I feel that in this way they are not very
+useful because it seems that the typeclass inference is not able to use them.-/
+--solution: state those as lemmas
+
+lemma countable_left_of_prod_of_nonempty [Nonempty β] (h : Countable (α × β)) : Countable α := by
+  contrapose h
+  rw [not_countable_iff] at *
+  infer_instance
+
+lemma countable_right_of_prod_of_nonempty [Nonempty α] (h : Countable (α × β)) : Countable β := by
+  contrapose h
+  rw [not_countable_iff] at *
+  infer_instance
+
+--TODO: what name should we use? in this name the first 'left' refers to the fact that we are talking about `α`, which is the left factor in the product, the second 'left' refers to the fact that the product is on the left argument of `CountableOrCountablyGenerated`
+lemma countableOrCountablyGenerated_left_of_prod_left_of_nonempty [Nonempty β]
+    [h : CountableOrCountablyGenerated (α × β) γ] :
+    CountableOrCountablyGenerated α γ := by
+  rcases h.countableOrCountablyGenerated with (h | h)
+  · have := countable_left_of_prod_of_nonempty h
+    infer_instance
+  · infer_instance
+
+lemma countableOrCountablyGenerated_right_of_prod_left_of_nonempty [Nonempty α]
+    [h : CountableOrCountablyGenerated (α × β) γ] :
+    CountableOrCountablyGenerated β γ := by
+  rcases h.countableOrCountablyGenerated with (h | h)
+  · have := countable_right_of_prod_of_nonempty h
+    infer_instance
+  · infer_instance
+
+--it would be nice to have also the following lemmas. I think they are true, but I cannot be sure,
+--because I cannot prove them even informally.
+--this seems like exactly what I'm looking for:
+--https://math.stackexchange.com/questions/3413063/if-product-sigma-field-is-countably-generated-is-each-factor
+--is it worth it to formalize that proof? I may need to formalize also the hint, if I don't find it on mathlib, this may take a bit of time but I think it may be worth it. However I have to decide whether to do it now or later.
+
+lemma countablyGenerated_left_of_prod_of_nonempty [Nonempty β] (h : CountablyGenerated (α × β)) : CountablyGenerated α := by
+  -- contrapose h
+  sorry
+
+lemma countablyGenerated_right_of_prod_of_nonempty [Nonempty α] (h : CountablyGenerated (α × β)) : CountablyGenerated β := by
+  -- contrapose h
+  sorry
+
+
+lemma countableOrCountablyGenerated_right_of_prod_right_of_nonempty [Nonempty β]
+    [h : CountableOrCountablyGenerated α (β × γ)] :
+    CountableOrCountablyGenerated α γ := by
+  rcases h.countableOrCountablyGenerated with (h | h)
+  · infer_instance
+  · have := countablyGenerated_right_of_prod_of_nonempty h
+    infer_instance
+
+lemma countableOrCountablyGenerated_left_of_prod_right_of_nonempty [Nonempty γ]
+    [h : CountableOrCountablyGenerated α (β × γ)] :
+    CountableOrCountablyGenerated α β := by
+  rcases h.countableOrCountablyGenerated with (h | h)
+  · infer_instance
+  · have := countablyGenerated_left_of_prod_of_nonempty h
+    infer_instance
+
+
+instance [Countable (α × β)] : Countable (β × α) :=
+  Countable.of_equiv _ (Equiv.prodComm α β)
+
+instance [h : CountableOrCountablyGenerated (α × β) γ] :
+    CountableOrCountablyGenerated (β × α) γ := by
+  rcases h with (h | h)
+  · exact ⟨Or.inl inferInstance⟩
+  · exact ⟨Or.inr h⟩
+
+--TODO: prove this, it may be useful to prove the analogous of Countable.of_equiv for CountablyGenerated, this may require a measurable equivalence. It should be a useful result to have in mathlib anyway. maybe there is a lemma about the measurable embeddings
+instance [CountablyGenerated (α × β)] : CountablyGenerated (β × α) := by
+  sorry
+
+instance [h : CountableOrCountablyGenerated (α × β) γ] :
+    CountableOrCountablyGenerated (β × α) γ := by
+  rcases h with (h | h)
+  · exact ⟨Or.inl inferInstance⟩
+  · exact ⟨Or.inr h⟩

--- a/TestingLowerBounds/ForMathlib/LogLikelihoodRatioCompProd.lean
+++ b/TestingLowerBounds/ForMathlib/LogLikelihoodRatioCompProd.lean
@@ -146,7 +146,7 @@ lemma integrable_llr_compProd_iff [CountableOrCountablyGenerated α β] [IsMarko
     ae_integrable_llr_of_integrable_llr_compProd h_ac h⟩,
     fun h ↦ integrable_llr_compProd_of_integrable_llr h_ac h.1.1 h.1.2 h.2⟩
 
-lemma kernel.integrable_llr_compProd_iff [CountableOrCountablyGenerated (α × β) γ]
+lemma kernel.integrable_llr_compProd_iff [CountableOrCountablyGenerated β γ]
     {κ₁ η₁ : kernel α β} [IsFiniteKernel κ₁] [IsFiniteKernel η₁]
     {κ₂ η₂ : kernel (α × β) γ} [IsMarkovKernel κ₂] [IsMarkovKernel η₂]
     (a : α) (h_ac : (κ₁ ⊗ₖ κ₂) a ≪ (η₁ ⊗ₖ η₂) a) :
@@ -154,9 +154,6 @@ lemma kernel.integrable_llr_compProd_iff [CountableOrCountablyGenerated (α × �
       ↔ Integrable (llr (κ₁ a) (η₁ a)) (κ₁ a)
         ∧ Integrable (fun b ↦ ∫ x, (llr (κ₂ (a, b)) (η₂ (a, b)) x) ∂(κ₂ (a, b))) (κ₁ a)
         ∧ ∀ᵐ b ∂κ₁ a, Integrable (llr (κ₂ (a, b)) (η₂ (a, b))) (κ₂ (a, b)) := by
-  by_cases h_empty : Nonempty α
-  swap; exact (not_nonempty_iff.mp h_empty |>.false a).elim
-  have := countableOrCountablyGenerated_right_of_prod_left_of_nonempty (α := α) (β := β) (γ := γ)
   simp_rw [kernel.compProd_apply_eq_compProd_snd'] at h_ac
   simp_rw [kernel.compProd_apply_eq_compProd_snd',
     ProbabilityTheory.integrable_llr_compProd_iff h_ac, kernel.snd'_apply]

--- a/TestingLowerBounds/ForMathlib/LogLikelihoodRatioCompProd.lean
+++ b/TestingLowerBounds/ForMathlib/LogLikelihoodRatioCompProd.lean
@@ -1,6 +1,7 @@
 import Mathlib.MeasureTheory.Measure.LogLikelihoodRatio
 import TestingLowerBounds.FDiv.CondFDiv
 import Mathlib.Analysis.SpecialFunctions.Log.NegMulLog
+import TestingLowerBounds.ForMathlib.CountableOrCountablyGenerated
 
 open Real MeasureTheory MeasurableSpace
 
@@ -145,6 +146,26 @@ lemma integrable_llr_compProd_iff [CountableOrCountablyGenerated α β] [IsMarko
     ae_integrable_llr_of_integrable_llr_compProd h_ac h⟩,
     fun h ↦ integrable_llr_compProd_of_integrable_llr h_ac h.1.1 h.1.2 h.2⟩
 
+lemma kernel.integrable_llr_compProd_iff [CountableOrCountablyGenerated (α × β) γ]
+    {κ₁ η₁ : kernel α β} [IsFiniteKernel κ₁] [IsFiniteKernel η₁]
+    {κ₂ η₂ : kernel (α × β) γ} [IsMarkovKernel κ₂] [IsMarkovKernel η₂]
+    (a : α) (h_ac : (κ₁ ⊗ₖ κ₂) a ≪ (η₁ ⊗ₖ η₂) a) :
+    Integrable (llr ((κ₁ ⊗ₖ κ₂) a) ((η₁ ⊗ₖ η₂) a)) ((κ₁ ⊗ₖ κ₂) a)
+      ↔ Integrable (llr (κ₁ a) (η₁ a)) (κ₁ a)
+        ∧ Integrable (fun b ↦ ∫ x, (llr (κ₂ (a, b)) (η₂ (a, b)) x) ∂(κ₂ (a, b))) (κ₁ a)
+        ∧ ∀ᵐ b ∂κ₁ a, Integrable (llr (κ₂ (a, b)) (η₂ (a, b))) (κ₂ (a, b)) := by
+  by_cases h_empty : Nonempty α
+  swap; exact (not_nonempty_iff.mp h_empty |>.false a).elim
+  have := countableOrCountablyGenerated_right_of_prod_left_of_nonempty (α := α) (β := β) (γ := γ)
+  simp_rw [kernel.compProd_apply_eq_compProd_snd'] at h_ac
+  simp_rw [kernel.compProd_apply_eq_compProd_snd',
+    ProbabilityTheory.integrable_llr_compProd_iff h_ac, kernel.snd'_apply]
+  by_cases h_int₁ : Integrable (llr (κ₁ a) (η₁ a)) (κ₁ a)
+  swap; tauto
+  by_cases h_int₂ : ∀ᵐ b ∂κ₁ a, Integrable (llr (κ₂ (a, b)) (η₂ (a, b))) (κ₂ (a, b))
+  swap; tauto
+  simp only [h_int₁, true_and, h_int₂, and_true]
+
 /- this lemma actually doesn't pertain the compProd, but for now I am still leaving it here,
 maybe when we put things in mathlib this could go in the basic file about llr,
 or maybe it still needs to go in a separate file, since it needs the definition of kernel,
@@ -153,8 +174,7 @@ lemma measurableSet_integrable_llr [CountableOrCountablyGenerated α β]
     (κ η : kernel α β) [IsFiniteKernel κ] [IsFiniteKernel η] :
     MeasurableSet {a | Integrable (fun b ↦ ((∂κ a/∂η a) b).toReal * llr (κ a) (η a) b) (η a)} := by
   simp_rw [llr_def]
-  exact ProbabilityTheory.measurableSet_integrable_f_rnDeriv κ η
-    continuous_mul_log.stronglyMeasurable
+  exact measurableSet_integrable_f_rnDeriv κ η continuous_mul_log.stronglyMeasurable
 
 lemma ae_compProd_integrable_llr_iff [CountableOrCountablyGenerated (α × β) γ] [SFinite μ]
     {ξ : kernel α β} [IsSFiniteKernel ξ]

--- a/TestingLowerBounds/ForMathlib/RadonNikodym.lean
+++ b/TestingLowerBounds/ForMathlib/RadonNikodym.lean
@@ -5,6 +5,10 @@ Authors: Rémy Degenne, Lorenzo Luccioli
 -/
 import Mathlib.Probability.Kernel.MeasureCompProd
 import Mathlib.Probability.Kernel.RadonNikodym
+import TestingLowerBounds.ForMathlib.KernelFstSnd
+import TestingLowerBounds.ForMathlib.CountableOrCountablyGenerated
+
+
 
 /-!
 # Radon-Nikodym derivative and Lebesgue decomposition for kernels
@@ -490,5 +494,18 @@ lemma Measure.absolutelyContinuous_compProd_right_iff
   ⟨absolutelyContinuous_kernel_of_compProd, Measure.absolutelyContinuous_compProd_right _⟩
 
 end MeasureCompProd
+
+--for now I am leaving it here, but in the future it should be moved to a more appropriate place, some file about absolute continuity, together with the other lemmas about absolute continuity, i.e. the lemmas directly above this one and some lemmas at the beginning of this file
+lemma absolutelyContinuous_compProd_iff {β : Type*} [MeasurableSpace β]
+    [MeasurableSpace.CountableOrCountablyGenerated (α × β) γ] {κ₁ η₁ : kernel α β}
+    {κ₂ η₂ : kernel (α × β) γ} [IsSFiniteKernel κ₁] [IsSFiniteKernel η₁] [IsFiniteKernel κ₂]
+    [IsFiniteKernel η₂] (a : α) [∀ b, NeZero (κ₂ (a, b))] :
+    (κ₁ ⊗ₖ κ₂) a ≪ (η₁ ⊗ₖ η₂) a ↔ κ₁ a ≪ η₁ a ∧ ∀ᵐ b ∂κ₁ a, κ₂ (a, b) ≪ η₂ (a, b) := by
+  by_cases h_empty : Nonempty α
+  swap; exact (not_nonempty_iff.mp h_empty |>.false a).elim
+  have := MeasurableSpace.countableOrCountablyGenerated_right_of_prod_left_of_nonempty
+    (α := α) (β := β) (γ := γ)
+  simp_rw [kernel.compProd_apply_eq_compProd_snd', kernel.Measure.absolutelyContinuous_compProd_iff,
+    kernel.snd'_apply]
 
 end ProbabilityTheory.kernel

--- a/TestingLowerBounds/ForMathlib/RadonNikodym.lean
+++ b/TestingLowerBounds/ForMathlib/RadonNikodym.lean
@@ -492,17 +492,12 @@ lemma Measure.absolutelyContinuous_compProd_right_iff
   ⟨absolutelyContinuous_kernel_of_compProd, Measure.absolutelyContinuous_compProd_right _⟩
 
 end MeasureCompProd
---offsprings
--- todo: move to a file about absolute continuity
+
 lemma absolutelyContinuous_compProd_iff {β : Type*} [MeasurableSpace β]
     [MeasurableSpace.CountableOrCountablyGenerated β γ] {κ₁ η₁ : kernel α β}
     {κ₂ η₂ : kernel (α × β) γ} [IsSFiniteKernel κ₁] [IsSFiniteKernel η₁] [IsFiniteKernel κ₂]
     [IsFiniteKernel η₂] (a : α) [∀ b, NeZero (κ₂ (a, b))] :
     (κ₁ ⊗ₖ κ₂) a ≪ (η₁ ⊗ₖ η₂) a ↔ κ₁ a ≪ η₁ a ∧ ∀ᵐ b ∂κ₁ a, κ₂ (a, b) ≪ η₂ (a, b) := by
-  -- by_cases h_empty : Nonempty α
-  -- swap; exact (not_nonempty_iff.mp h_empty |>.false a).elim
-  -- have := MeasurableSpace.countableOrCountablyGenerated_right_of_prod_left_of_nonempty
-  --   (α := α) (β := β) (γ := γ)
   simp_rw [kernel.compProd_apply_eq_compProd_snd', kernel.Measure.absolutelyContinuous_compProd_iff,
     kernel.snd'_apply]
 

--- a/TestingLowerBounds/ForMathlib/RadonNikodym.lean
+++ b/TestingLowerBounds/ForMathlib/RadonNikodym.lean
@@ -8,8 +8,6 @@ import Mathlib.Probability.Kernel.RadonNikodym
 import TestingLowerBounds.ForMathlib.KernelFstSnd
 import TestingLowerBounds.ForMathlib.CountableOrCountablyGenerated
 
-
-
 /-!
 # Radon-Nikodym derivative and Lebesgue decomposition for kernels
 
@@ -494,17 +492,17 @@ lemma Measure.absolutelyContinuous_compProd_right_iff
   ⟨absolutelyContinuous_kernel_of_compProd, Measure.absolutelyContinuous_compProd_right _⟩
 
 end MeasureCompProd
-
---for now I am leaving it here, but in the future it should be moved to a more appropriate place, some file about absolute continuity, together with the other lemmas about absolute continuity, i.e. the lemmas directly above this one and some lemmas at the beginning of this file
+--offsprings
+-- todo: move to a file about absolute continuity
 lemma absolutelyContinuous_compProd_iff {β : Type*} [MeasurableSpace β]
-    [MeasurableSpace.CountableOrCountablyGenerated (α × β) γ] {κ₁ η₁ : kernel α β}
+    [MeasurableSpace.CountableOrCountablyGenerated β γ] {κ₁ η₁ : kernel α β}
     {κ₂ η₂ : kernel (α × β) γ} [IsSFiniteKernel κ₁] [IsSFiniteKernel η₁] [IsFiniteKernel κ₂]
     [IsFiniteKernel η₂] (a : α) [∀ b, NeZero (κ₂ (a, b))] :
     (κ₁ ⊗ₖ κ₂) a ≪ (η₁ ⊗ₖ η₂) a ↔ κ₁ a ≪ η₁ a ∧ ∀ᵐ b ∂κ₁ a, κ₂ (a, b) ≪ η₂ (a, b) := by
-  by_cases h_empty : Nonempty α
-  swap; exact (not_nonempty_iff.mp h_empty |>.false a).elim
-  have := MeasurableSpace.countableOrCountablyGenerated_right_of_prod_left_of_nonempty
-    (α := α) (β := β) (γ := γ)
+  -- by_cases h_empty : Nonempty α
+  -- swap; exact (not_nonempty_iff.mp h_empty |>.false a).elim
+  -- have := MeasurableSpace.countableOrCountablyGenerated_right_of_prod_left_of_nonempty
+  --   (α := α) (β := β) (γ := γ)
   simp_rw [kernel.compProd_apply_eq_compProd_snd', kernel.Measure.absolutelyContinuous_compProd_iff,
     kernel.snd'_apply]
 

--- a/TestingLowerBounds/KullbackLeibler.lean
+++ b/TestingLowerBounds/KullbackLeibler.lean
@@ -373,6 +373,13 @@ lemma condKL_zero_measure : condKL κ η 0 = 0 := by
   rw [condKL_of_ae_ne_top_of_integrable hf_ae integrable_zero_measure]
   simp only [integral_zero_measure, EReal.coe_zero]
 
+@[simp]
+lemma condKL_isEmpty_left [IsEmpty α] : condKL κ η μ = 0 := by
+  have h : μ = 0 := by
+    ext s
+    exact Set.eq_empty_of_isEmpty s ▸ measure_empty
+  exact h ▸ condKL_zero_measure
+
 lemma condKL_ne_bot (κ η : kernel α β) (μ : Measure α) : condKL κ η μ ≠ ⊥ := by
   rw [condKL]
   split_ifs with h

--- a/TestingLowerBounds/KullbackLeibler.lean
+++ b/TestingLowerBounds/KullbackLeibler.lean
@@ -633,13 +633,7 @@ lemma kl_compProd_kernel_of_ae_ac_of_ae_integrable [CountableOrCountablyGenerate
     (h_ae_int : ∀ᵐ a ∂μ, Integrable (llr ((κ₁ ⊗ₖ κ₂) a) ((η₁ ⊗ₖ η₂) a)) ((κ₁ ⊗ₖ κ₂) a)) :
     ∀ᵐ a ∂μ, (kl ((κ₁ ⊗ₖ κ₂) a) ((η₁ ⊗ₖ η₂) a)).toReal
       = (kl (κ₁ a) (η₁ a)).toReal + ∫ b, (kl (κ₂ (a, b)) (η₂ (a, b))).toReal ∂κ₁ a := by
-  -- by_cases h_empty : Nonempty α
-  -- swap; simp only [not_nonempty_iff.mp h_empty, IsEmpty.forall_iff, eventually_of_forall]
-  -- have := countableOrCountablyGenerated_right_of_prod_left_of_nonempty (α := α) (β := β) (γ := γ)
   simp only [eventually_congr (h_ac.mono (fun a h ↦ (kernel.integrable_llr_compProd_iff' a h))),
-
-  -- simp only [eventually_congr (h_ac.mono (fun a h ↦ (kernel.integrable_llr_compProd_iff a h))),
-
     eventually_and] at h_ae_int
   simp only [kernel.absolutelyContinuous_compProd_iff, eventually_and] at h_ac
   filter_upwards [h_ac.1, h_ac.2, h_ae_int.1, h_ae_int.2.1, h_ae_int.2.2] with a ha_ac₁ ha_ac₂

--- a/TestingLowerBounds/KullbackLeibler.lean
+++ b/TestingLowerBounds/KullbackLeibler.lean
@@ -11,6 +11,7 @@ import TestingLowerBounds.ForMathlib.IntegralCongr2
 import TestingLowerBounds.ForMathlib.KernelFstSnd
 import TestingLowerBounds.ForMathlib.Measurable
 import TestingLowerBounds.ForMathlib.IntegrableNonneg
+import TestingLowerBounds.ForMathlib.CountableOrCountablyGenerated
 
 /-!
 # Kullback-Leibler divergence
@@ -606,51 +607,36 @@ lemma kl_fst_add_condKL [StandardBorelSpace β] [Nonempty β] {μ ν : Measure (
     kl μ.fst ν.fst + condKL μ.condKernel ν.condKernel μ.fst = kl μ ν := by
   rw [← kl_compProd, μ.compProd_fst_condKernel, ν.compProd_fst_condKernel]
 
-
-/- TODO: this can be generalized, relaxing the markov kernel hypothesis, it is sufficient that
-the kernels are finite and that they are not zero, but just stating that is not enough, because
-the actual hypothesys needed is that `∀ b, NeZero (snd' κ₂ a) b` but this is very ugly to use as
-an explicit hypothesis, maybe it is worth it to add an instance saying that if `NeZero κ (a, b)`
-then `NeZero (snd' κ a) b`.
-To fix this maybe we can add the instance that if `NeZero κ (a, b)` then `NeZero (snd' κ a) b`,
-then it should be able to generalize this lemma.
-TODO: these lemmas may be put in another file, decide how to organize the files, about composition
-of kernels. -/
-lemma kernel.absolutelyContinuous_compProd_iff [CountableOrCountablyGenerated β γ]
-    {κ₁ η₁ : kernel α β} {κ₂ η₂ : kernel (α × β) γ} [IsSFiniteKernel κ₁] [IsSFiniteKernel η₁]
-    [IsMarkovKernel κ₂] [IsMarkovKernel η₂] (a : α) :
-    (κ₁ ⊗ₖ κ₂) a ≪ (η₁ ⊗ₖ η₂) a ↔ κ₁ a ≪ η₁ a ∧ ∀ᵐ b ∂κ₁ a, κ₂ (a, b) ≪ η₂ (a, b) := by
-  simp_rw [kernel.compProd_apply_eq_compProd_snd',
-    kernel.Measure.absolutelyContinuous_compProd_iff, kernel.snd'_apply]
-
-lemma kernel.integrable_llr_compProd_iff [CountableOrCountablyGenerated β γ] {κ₁ η₁ : kernel α β}
-    {κ₂ η₂ : kernel (α × β) γ} [IsFiniteKernel κ₁] [IsFiniteKernel η₁] [IsMarkovKernel κ₂]
-    [IsMarkovKernel η₂] (a : α) (h_ac : (κ₁ ⊗ₖ κ₂) a ≪ (η₁ ⊗ₖ η₂) a) :
+/-TODO: this is just a thin wrapper around kernel.integrable_llr_compProd_iff, so that that lemma
+could be put in an outside file. But I have realised that the choice of having 2 instead of 2' as
+the hp of choice about integrability here may be a bad one, because in cases like this one
+it does not allow to move stuff outside this file, as it relies on the definition of kl.
+Moreover in general it is the opposite choice to what is done in fDiv, and in fDiv the other choice
+is much more convenient, because it allows to disregard the singular part inside the definition of
+fDiv when talking about integrability. So I think it may be better to reverse this choice here,
+changing the lemmas like condKL_ne_top_iff from 2 to 2'-/
+lemma kernel.integrable_llr_compProd_iff' [CountableOrCountablyGenerated (α × β) γ]
+    {κ₁ η₁ : kernel α β} {κ₂ η₂ : kernel (α × β) γ} [IsFiniteKernel κ₁] [IsFiniteKernel η₁]
+    [IsMarkovKernel κ₂] [IsMarkovKernel η₂] (a : α) (h_ac : (κ₁ ⊗ₖ κ₂) a ≪ (η₁ ⊗ₖ η₂) a) :
     Integrable (llr ((κ₁ ⊗ₖ κ₂) a) ((η₁ ⊗ₖ η₂) a)) ((κ₁ ⊗ₖ κ₂) a)
       ↔ Integrable (llr (κ₁ a) (η₁ a)) (κ₁ a)
         ∧ Integrable (fun b ↦ (kl (κ₂ (a, b)) (η₂ (a, b))).toReal) (κ₁ a)
         ∧ ∀ᵐ b ∂κ₁ a, Integrable (llr (κ₂ (a, b)) (η₂ (a, b))) (κ₂ (a, b)) := by
+  convert kernel.integrable_llr_compProd_iff a h_ac using 3
+  simp_rw [← kernel.snd'_apply]
   have h_ac' := kernel.absolutelyContinuous_compProd_iff a |>.mp h_ac |>.2
-  simp_rw [kernel.compProd_apply_eq_compProd_snd'] at h_ac
-  simp_rw [kernel.compProd_apply_eq_compProd_snd',
-    ProbabilityTheory.integrable_llr_compProd_iff h_ac, kernel.snd'_apply]
-  by_cases h_int₁ : Integrable (llr (κ₁ a) (η₁ a)) (κ₁ a)
-  swap; tauto
-  by_cases h_int₂ : ∀ᵐ b ∂κ₁ a, Integrable (llr (κ₂ (a, b)) (η₂ (a, b))) (κ₂ (a, b))
-  swap; tauto
-  simp only [h_int₁, true_and, h_int₂, and_true]
-  apply integrable_congr
-  filter_upwards [h_ac'] with b hb_ac
-  rw [kl_toReal_of_ac hb_ac]
+  exact integrable_kl_iff h_ac'
 
-lemma kl_compProd_kernel_of_ae_ac_of_ae_integrable [CountableOrCountablyGenerated β γ]
+lemma kl_compProd_kernel_of_ae_ac_of_ae_integrable [CountableOrCountablyGenerated (α × β) γ]
     {κ₁ η₁ : kernel α β} {κ₂ η₂ : kernel (α × β) γ} [IsFiniteKernel κ₁] [IsFiniteKernel η₁]
-    [IsMarkovKernel κ₂] [IsMarkovKernel η₂]
-    (h_ac : ∀ᵐ a ∂μ, (κ₁ ⊗ₖ κ₂) a ≪ (η₁ ⊗ₖ η₂) a)
+    [IsMarkovKernel κ₂] [IsMarkovKernel η₂] (h_ac : ∀ᵐ a ∂μ, (κ₁ ⊗ₖ κ₂) a ≪ (η₁ ⊗ₖ η₂) a)
     (h_ae_int : ∀ᵐ a ∂μ, Integrable (llr ((κ₁ ⊗ₖ κ₂) a) ((η₁ ⊗ₖ η₂) a)) ((κ₁ ⊗ₖ κ₂) a)) :
     ∀ᵐ a ∂μ, (kl ((κ₁ ⊗ₖ κ₂) a) ((η₁ ⊗ₖ η₂) a)).toReal
       = (kl (κ₁ a) (η₁ a)).toReal + ∫ b, (kl (κ₂ (a, b)) (η₂ (a, b))).toReal ∂κ₁ a := by
-  simp only [eventually_congr (h_ac.mono (fun a h ↦ (kernel.integrable_llr_compProd_iff a h))),
+  by_cases h_empty : Nonempty α
+  swap; simp only [not_nonempty_iff.mp h_empty, IsEmpty.forall_iff, eventually_of_forall]
+  have := countableOrCountablyGenerated_right_of_prod_left_of_nonempty (α := α) (β := β) (γ := γ)
+  simp only [eventually_congr (h_ac.mono (fun a h ↦ (kernel.integrable_llr_compProd_iff' a h))),
     eventually_and] at h_ae_int
   simp only [kernel.absolutelyContinuous_compProd_iff, eventually_and] at h_ac
   filter_upwards [h_ac.1, h_ac.2, h_ae_int.1, h_ae_int.2.1, h_ae_int.2.2] with a ha_ac₁ ha_ac₂
@@ -664,9 +650,7 @@ lemma kl_compProd_kernel_of_ae_ac_of_ae_integrable [CountableOrCountablyGenerate
     (condKL_ne_bot (kernel.snd' κ₂ a) (kernel.snd' η₂ a) (κ₁ a)),
     condKL_ne_top_iff'.mp h_snd_ne_top, EReal.toReal_coe, kernel.snd'_apply]
 
--- todo: can we avoid the two different `CountableOrCountablyGenerated` assumptions?
-lemma condKL_compProd_kernel_eq_top [CountableOrCountablyGenerated (α × β) γ]
-    [CountableOrCountablyGenerated β γ] {κ₁ η₁ : kernel α β}
+lemma condKL_compProd_kernel_eq_top [CountableOrCountablyGenerated (α × β) γ] {κ₁ η₁ : kernel α β}
     {κ₂ η₂ : kernel (α × β) γ} [IsMarkovKernel κ₁] [IsMarkovKernel η₁] [IsMarkovKernel κ₂]
     [IsMarkovKernel η₂] [SFinite μ] :
     condKL (κ₁ ⊗ₖ κ₂) (η₁ ⊗ₖ η₂) μ = ⊤ ↔ condKL κ₁ η₁ μ = ⊤ ∨ condKL κ₂ η₂ (μ ⊗ₘ κ₁) = ⊤ := by
@@ -680,8 +664,7 @@ lemma condKL_compProd_kernel_eq_top [CountableOrCountablyGenerated (α × β) γ
   rw [← Measure.ae_compProd_iff (kernel.measurableSet_absolutelyContinuous _ _)] at h_ac'
   by_cases h_ae_int : ∀ᵐ a ∂μ, Integrable (llr ((κ₁ ⊗ₖ κ₂) a) ((η₁ ⊗ₖ η₂) a)) ((κ₁ ⊗ₖ κ₂) a)
     <;> have h_ae_int' := h_ae_int
-    <;> simp only [eventually_congr
-        (h_ac.mono (fun a h ↦ (kernel.integrable_llr_compProd_iff a h))),
+    <;> simp only [eventually_congr (h_ac.mono (fun a h ↦ (kernel.integrable_llr_compProd_iff' a h))),
       eventually_and, not_and_or] at h_ae_int'
     <;> simp only [h_ae_int, h_ae_int', not_false_eq_true, true_or, true_and, not_true, true_iff,
       false_or, not_and_or, ae_compProd_integrable_llr_iff h_ac'.2, Measure.integrable_compProd_iff
@@ -704,9 +687,9 @@ lemma condKL_compProd_kernel_eq_top [CountableOrCountablyGenerated (α × β) γ
   · filter_upwards with a using integral_nonneg (fun b ↦ EReal.toReal_nonneg (kl_nonneg _ _))
   · filter_upwards with a using EReal.toReal_nonneg (kl_nonneg _ _)
 
-lemma condKL_compProd_kernel [CountableOrCountablyGenerated (α × β) γ]
-    [CountableOrCountablyGenerated β γ] {κ₁ η₁ : kernel α β} {κ₂ η₂ : kernel (α × β) γ}
-    [IsMarkovKernel κ₁] [IsMarkovKernel η₁] [IsMarkovKernel κ₂] [IsMarkovKernel η₂] [SFinite μ] :
+lemma condKL_compProd_kernel [CountableOrCountablyGenerated (α × β) γ] {κ₁ η₁ : kernel α β}
+    {κ₂ η₂ : kernel (α × β) γ} [IsMarkovKernel κ₁] [IsMarkovKernel η₁] [IsMarkovKernel κ₂]
+    [IsMarkovKernel η₂] [SFinite μ] :
     condKL (κ₁ ⊗ₖ κ₂) (η₁ ⊗ₖ η₂) μ = condKL κ₁ η₁ μ + condKL κ₂ η₂ (μ ⊗ₘ κ₁) := by
   by_cases hp : condKL (κ₁ ⊗ₖ κ₂) (η₁ ⊗ₖ η₂) μ = ⊤
   · rw [hp]

--- a/TestingLowerBounds/KullbackLeibler.lean
+++ b/TestingLowerBounds/KullbackLeibler.lean
@@ -615,7 +615,7 @@ Moreover in general it is the opposite choice to what is done in fDiv, and in fD
 is much more convenient, because it allows to disregard the singular part inside the definition of
 fDiv when talking about integrability. So I think it may be better to reverse this choice here,
 changing the lemmas like condKL_ne_top_iff from 2 to 2'-/
-lemma kernel.integrable_llr_compProd_iff' [CountableOrCountablyGenerated (α × β) γ]
+lemma kernel.integrable_llr_compProd_iff' [CountableOrCountablyGenerated β γ]
     {κ₁ η₁ : kernel α β} {κ₂ η₂ : kernel (α × β) γ} [IsFiniteKernel κ₁] [IsFiniteKernel η₁]
     [IsMarkovKernel κ₂] [IsMarkovKernel η₂] (a : α) (h_ac : (κ₁ ⊗ₖ κ₂) a ≪ (η₁ ⊗ₖ η₂) a) :
     Integrable (llr ((κ₁ ⊗ₖ κ₂) a) ((η₁ ⊗ₖ η₂) a)) ((κ₁ ⊗ₖ κ₂) a)
@@ -627,16 +627,19 @@ lemma kernel.integrable_llr_compProd_iff' [CountableOrCountablyGenerated (α × 
   have h_ac' := kernel.absolutelyContinuous_compProd_iff a |>.mp h_ac |>.2
   exact integrable_kl_iff h_ac'
 
-lemma kl_compProd_kernel_of_ae_ac_of_ae_integrable [CountableOrCountablyGenerated (α × β) γ]
+lemma kl_compProd_kernel_of_ae_ac_of_ae_integrable [CountableOrCountablyGenerated β γ]
     {κ₁ η₁ : kernel α β} {κ₂ η₂ : kernel (α × β) γ} [IsFiniteKernel κ₁] [IsFiniteKernel η₁]
     [IsMarkovKernel κ₂] [IsMarkovKernel η₂] (h_ac : ∀ᵐ a ∂μ, (κ₁ ⊗ₖ κ₂) a ≪ (η₁ ⊗ₖ η₂) a)
     (h_ae_int : ∀ᵐ a ∂μ, Integrable (llr ((κ₁ ⊗ₖ κ₂) a) ((η₁ ⊗ₖ η₂) a)) ((κ₁ ⊗ₖ κ₂) a)) :
     ∀ᵐ a ∂μ, (kl ((κ₁ ⊗ₖ κ₂) a) ((η₁ ⊗ₖ η₂) a)).toReal
       = (kl (κ₁ a) (η₁ a)).toReal + ∫ b, (kl (κ₂ (a, b)) (η₂ (a, b))).toReal ∂κ₁ a := by
-  by_cases h_empty : Nonempty α
-  swap; simp only [not_nonempty_iff.mp h_empty, IsEmpty.forall_iff, eventually_of_forall]
-  have := countableOrCountablyGenerated_right_of_prod_left_of_nonempty (α := α) (β := β) (γ := γ)
+  -- by_cases h_empty : Nonempty α
+  -- swap; simp only [not_nonempty_iff.mp h_empty, IsEmpty.forall_iff, eventually_of_forall]
+  -- have := countableOrCountablyGenerated_right_of_prod_left_of_nonempty (α := α) (β := β) (γ := γ)
   simp only [eventually_congr (h_ac.mono (fun a h ↦ (kernel.integrable_llr_compProd_iff' a h))),
+
+  -- simp only [eventually_congr (h_ac.mono (fun a h ↦ (kernel.integrable_llr_compProd_iff a h))),
+
     eventually_and] at h_ae_int
   simp only [kernel.absolutelyContinuous_compProd_iff, eventually_and] at h_ac
   filter_upwards [h_ac.1, h_ac.2, h_ae_int.1, h_ae_int.2.1, h_ae_int.2.2] with a ha_ac₁ ha_ac₂
@@ -654,6 +657,12 @@ lemma condKL_compProd_kernel_eq_top [CountableOrCountablyGenerated (α × β) γ
     {κ₂ η₂ : kernel (α × β) γ} [IsMarkovKernel κ₁] [IsMarkovKernel η₁] [IsMarkovKernel κ₂]
     [IsMarkovKernel η₂] [SFinite μ] :
     condKL (κ₁ ⊗ₖ κ₂) (η₁ ⊗ₖ η₂) μ = ⊤ ↔ condKL κ₁ η₁ μ = ⊤ ∨ condKL κ₂ η₂ (μ ⊗ₘ κ₁) = ⊤ := by
+  by_cases h_empty : Nonempty α
+  swap
+  · replace h_empty := not_nonempty_iff.mp h_empty
+    simp only [condKL_isEmpty_left]
+    tauto
+  have := countableOrCountablyGenerated_right_of_prod_left_of_nonempty (α := α) (β := β) (γ := γ)
   simp_rw [condKL_eq_top_iff,
     Measure.ae_compProd_iff (kernel.measurableSet_absolutelyContinuous _ _)]
   by_cases h_ac : ∀ᵐ a ∂μ, (κ₁ ⊗ₖ κ₂) a ≪ (η₁ ⊗ₖ η₂) a
@@ -691,6 +700,11 @@ lemma condKL_compProd_kernel [CountableOrCountablyGenerated (α × β) γ] {κ�
     {κ₂ η₂ : kernel (α × β) γ} [IsMarkovKernel κ₁] [IsMarkovKernel η₁] [IsMarkovKernel κ₂]
     [IsMarkovKernel η₂] [SFinite μ] :
     condKL (κ₁ ⊗ₖ κ₂) (η₁ ⊗ₖ η₂) μ = condKL κ₁ η₁ μ + condKL κ₂ η₂ (μ ⊗ₘ κ₁) := by
+  by_cases h_empty : Nonempty α
+  swap
+  · replace h_empty := not_nonempty_iff.mp h_empty
+    simp only [condKL_isEmpty_left, zero_add]
+  have := countableOrCountablyGenerated_right_of_prod_left_of_nonempty (α := α) (β := β) (γ := γ)
   by_cases hp : condKL (κ₁ ⊗ₖ κ₂) (η₁ ⊗ₖ η₂) μ = ⊤
   · rw [hp]
     rw [condKL_compProd_kernel_eq_top] at hp


### PR DESCRIPTION
Fix the problem of having to state two `CountableOrCountablyGenerated` hypotheses (`[CountableOrCountablyGenerated (α × β) γ]
    [CountableOrCountablyGenerated β γ]`), when only one would suffice (`[CountableOrCountablyGenerated (α × β) γ]`). 

- Add `condKL_isEmpty_left`
- Add file `CountableOrCountablyGenerated.lean`
- Move `kernel.integrable_llr_compProd_iff` to the file about llr compProd
- Move `absolutelyContinuous_compProd_iff` to `RadonNicodym.lean`
- Cleanup