### PR TITLE
add lemmas about the kl divergence

### DIFF
--- a/TestingLowerBounds/KullbackLeibler.lean
+++ b/TestingLowerBounds/KullbackLeibler.lean
@@ -214,15 +214,17 @@ lemma kl_nonneg' (μ ν : Measure α) [IsFiniteMeasure μ] [IsFiniteMeasure ν]
 lemma kl_nonneg (μ ν : Measure α) [IsProbabilityMeasure μ] [IsProbabilityMeasure ν] :
     0 ≤ kl μ ν := kl_nonneg' μ ν (by simp)
 
--- This is wrong as it is stated, infact `kl μ ν` is zero also if `μ = 0`.
-lemma kl_eq_zero_iff [SigmaFinite μ] [SigmaFinite ν] : kl μ ν = 0 ↔ μ = ν := by
+-- We may need to modify the hypotheses of this lemma, maybe `μ Set.univ ≥ ν Set.univ` is enough,
+-- like in the previous lemma, and we probably need finiteness of the measures.
+lemma kl_eq_zero_iff [SigmaFinite μ] [SigmaFinite ν] (h : μ Set.univ = ν Set.univ) :
+  kl μ ν = 0 ↔ μ = ν := by
   constructor <;> intro h
   · by_cases hμν : μ ≪ ν
     swap; · rw [kl_of_not_ac hμν] at h; simp_all only [EReal.top_ne_zero]
     by_cases h_int : Integrable (llr μ ν) μ
     swap; · rw [kl_of_not_integrable h_int] at h; simp_all only [EReal.top_ne_zero]
     sorry -- TODO : decide what proof strategy to use here, maybe we could use the fact that
-    -- jensen's inequality is an equality iff the function is constant a.e., but I don't know wether
+    -- jensen's inequality is an equality iff the function is constant a.e., but I don't know whether
     -- this is in mathlib
   · exact h ▸ kl_self ν
 

--- a/blueprint/src/sections/kl_divergence.tex
+++ b/blueprint/src/sections/kl_divergence.tex
@@ -81,29 +81,29 @@ Since $\KL$ is an f-divergence, every inequality for f-divergences can be transl
 
 \begin{theorem}[Marginals]
   \label{thm:kl_fst_le}
-  %\lean{}
-  %\leanok
+  \lean{ProbabilityTheory.kl_fst_le, ProbabilityTheory.kl_snd_le}
+  \leanok
   \uses{def:KL}
   Let $\mu$ and $\nu$ be two measures on $\mathcal X \times \mathcal Y$ where $\mathcal Y$ is standard Borel, and let $\mu_X, \nu_X$ be their marginals on $\mathcal X$.
   Then $\KL(\mu_X, \nu_X) \le \KL(\mu, \nu)$.
   Similarly, for $\mathcal X$ standard Borel and $\mu_Y, \nu_Y$ the marginals on $\mathcal Y$, $\KL(\mu_Y, \nu_Y) \le \KL(\mu, \nu)$.
 \end{theorem}
 
-\begin{proof}
+\begin{proof} \leanok
 \uses{thm:fDiv_fst_le, lem:kl_eq_fDiv}
 Apply Theorem~\ref{thm:fDiv_fst_le}.
 \end{proof}
 
 \begin{theorem}[Data-processing]
   \label{thm:kl_data_proc}
-  %\lean{}
-  %\leanok
+  \lean{ProbabilityTheory.kl_comp_right_le}
+  \leanok
   \uses{def:KL}
   Let $\mu, \nu$ be two measures on $\mathcal X$ and let $\kappa : \mathcal X \rightsquigarrow \mathcal Y$ be a Markov kernel.
   Then $\KL(\kappa \circ \mu, \kappa \circ \nu) \le \KL(\mu, \nu)$.
 \end{theorem}
 
-\begin{proof}
+\begin{proof} \leanok
 \uses{thm:fDiv_data_proc, lem:kl_eq_fDiv}
 Apply Theorem~\ref{thm:fDiv_data_proc}.
 \end{proof}
@@ -252,10 +252,11 @@ Write $\mu = \mu_X \otimes \mu_{Y|X}$ and $\nu = \nu_X \otimes \nu_{Y|X}$, then 
   $$\KL(\mu_1\times \mu_2, \nu_1 \times \nu_2) = \KL(\mu_1, \nu_1) + \KL(\mu_2, \nu_2) \mu_1 (\mathcal X) \: .$$
 \end{lemma}
 
-\begin{proof}
+\begin{proof} \leanok
 \uses{thm:kl_compProd, lem:condKL_const}
 Write $\mu_1 \times \mu_2$ and $\nu_1 \times \nu_2$ as composition products of a measure and a constant kernel, then apply the chain rule (Theorem~\ref{thm:kl_compProd}) and Lemma~\ref{lem:condKL_const}.
 \end{proof}
+ 
 \begin{theorem}[Tensorization]
   \label{thm:kl_prod_two}
   \lean{ProbabilityTheory.kl_prod_two}


### PR DESCRIPTION
- Generalize `kl_nonneg` to finite measures, `kl_nonneg` reemained for the version aobut probability measures, the general version is called `kl_nonneg'`
- Add `kl_fst_le`, `kl_snd_le`, `le_kl_compProd`
- Generalize `kl_compProd_left` from markov kernels to finite, nonzero kernels
- Add the data processing inequality for kl and realted lemmas
- Update blueprint
- Cleanup

Depends on #63