### PR TITLE
Add and prove lemmas about `bayesBinaryRisk`

### DIFF
--- a/TestingLowerBounds/Kernel/Monoidal.lean
+++ b/TestingLowerBounds/Kernel/Monoidal.lean
@@ -88,6 +88,11 @@ lemma discard_apply (a : α) : discard α a = Measure.dirac () := deterministic_
 lemma comp_discard (κ : kernel α β) [IsMarkovKernel κ] : discard β ∘ₖ κ = discard α := by
   ext a s hs; simp [comp_apply' _ _ _ hs]
 
+@[simp]
+lemma _root_.MeasureTheory.Measure.comp_discard (μ : Measure α) :
+    μ.bind (discard α) = μ Set.univ • (Measure.dirac ()) := by
+  ext s hs; simp [Measure.bind_apply hs (kernel.measurable _), mul_comm]
+
 end Discard
 
 section Swap

--- a/TestingLowerBounds/MeasureCompProd.lean
+++ b/TestingLowerBounds/MeasureCompProd.lean
@@ -91,6 +91,13 @@ lemma Measure.compProd_const {ν : Measure β} [SFinite μ] [SFinite ν] :
   rw [Measure.compProd_apply hs, Measure.prod_apply hs]
   simp_rw [kernel.const_apply]
 
+@[simp]
+lemma Measure.comp_const {ν : Measure β} :
+    μ ∘ₘ (kernel.const α ν) = μ Set.univ • ν := by
+  ext s hs
+  simp_rw [Measure.bind_apply hs (kernel.measurable _), kernel.const_apply, lintegral_const]
+  simp [mul_comm]
+
 lemma Measure.compProd_apply_toReal [SFinite μ] [IsFiniteKernel κ]
     {s : Set (α × β)} (hs : MeasurableSet s) :
     ((μ ⊗ₘ κ) s).toReal = ∫ x, (κ x (Prod.mk x ⁻¹' s)).toReal ∂μ := by
@@ -417,15 +424,6 @@ lemma integrable_f_rnDeriv_compProd_right_iff [IsFiniteMeasure μ]
 
 end Integrable
 
-/--The composition product of a measure and a constant kernel is the product between the two
-measures.-/
-@[simp]
-lemma compProd_const {ν : Measure β} [SFinite ν] [SFinite μ] :
-    μ ⊗ₘ (kernel.const α ν) = μ.prod ν := by
-  ext s hs
-  rw [Measure.compProd_apply hs, Measure.prod_apply hs]
-  simp_rw [kernel.const_apply]
-
 lemma compProd_apply_toReal [SFinite μ] [IsFiniteKernel κ]
     {s : Set (α × β)} (hs : MeasurableSet s) :
     ((μ ⊗ₘ κ) s).toReal = ∫ x, (κ x (Prod.mk x ⁻¹' s)).toReal ∂μ := by
@@ -440,6 +438,16 @@ lemma compProd_univ_toReal [SFinite μ] [IsFiniteKernel κ] :
     ((μ ⊗ₘ κ) Set.univ).toReal = ∫ x, (κ x Set.univ).toReal ∂μ :=
   compProd_apply_toReal MeasurableSet.univ
 
+lemma Measure.compProd_apply_univ [SFinite μ] [IsMarkovKernel κ] :
+    (μ ⊗ₘ κ) Set.univ = μ (Set.univ) := by
+  rw [Measure.compProd_apply MeasurableSet.univ]
+  simp
+
+lemma Measure.comp_apply_univ [IsMarkovKernel κ] :
+    (μ ∘ₘ κ) Set.univ = μ (Set.univ) := by
+  rw [Measure.bind_apply MeasurableSet.univ (kernel.measurable κ)]
+  simp
+
 instance [SFinite μ] [IsSFiniteKernel κ] : SFinite (μ ∘ₘ κ) := by
   rw [Measure.comp_eq_snd_compProd]
   infer_instance
@@ -451,5 +459,19 @@ instance [IsFiniteMeasure μ] [IsFiniteKernel κ] : IsFiniteMeasure (μ ∘ₘ �
 instance [IsProbabilityMeasure μ] [IsMarkovKernel κ] : IsProbabilityMeasure (μ ∘ₘ κ) := by
   rw [Measure.comp_eq_snd_compProd]
   infer_instance
+
+--this is already PRed to mathlib, see #14471, when it gets merged and we bump, remove this
+instance [hμ : SFinite μ] (a : ℝ≥0∞) : SFinite (a • μ) := by
+  sorry
+
+lemma Measure.compProd_smul_left (a : ℝ≥0∞) [SFinite μ] [IsSFiniteKernel κ] :
+    (a • μ) ⊗ₘ κ = a • (μ ⊗ₘ κ) := by
+  ext s hs
+  simp only [Measure.compProd_apply hs, lintegral_smul_measure, Measure.smul_apply, smul_eq_mul]
+
+lemma Measure.comp_smul_left (a : ℝ≥0∞) : (a • μ) ∘ₘ κ = a • (μ ∘ₘ κ) := by
+  ext s hs
+  simp only [Measure.bind_apply hs (kernel.measurable _), lintegral_smul_measure,
+    Measure.smul_apply, smul_eq_mul]
 
 end ProbabilityTheory

--- a/TestingLowerBounds/Testing/Binary.lean
+++ b/TestingLowerBounds/Testing/Binary.lean
@@ -357,9 +357,8 @@ lemma bayesBinaryRisk_dirac (a b : ℝ≥0∞) (x : 𝒳) (π : Measure Bool) :
 
 lemma bayesBinaryRisk_le_min (μ ν : Measure 𝒳) (π : Measure Bool) :
     bayesBinaryRisk μ ν π ≤ min (π {false} * μ Set.univ) (π {true} * ν Set.univ) := by
-  let η : kernel 𝒳 Unit := kernel.discard 𝒳
-  convert bayesBinaryRisk_le_bayesBinaryRisk_comp μ ν π η
-  simp_rw [η, Measure.comp_discard, bayesBinaryRisk_dirac]
+  convert bayesBinaryRisk_le_bayesBinaryRisk_comp μ ν π (kernel.discard 𝒳)
+  simp_rw [Measure.comp_discard, bayesBinaryRisk_dirac]
 
 lemma bayesBinaryRisk_symm (μ ν : Measure 𝒳) (π : Measure Bool) :
     bayesBinaryRisk μ ν π = bayesBinaryRisk ν μ (π.map Bool.not) := by

--- a/TestingLowerBounds/Testing/Binary.lean
+++ b/TestingLowerBounds/Testing/Binary.lean
@@ -253,7 +253,8 @@ lemma bayesBinaryRisk_eq (μ ν : Measure 𝒳) (π : Measure Bool) :
 variable {π : Measure Bool}
 
 --rename this and put it in a better place
-lemma mem_set_bool (s : Set Bool) : s = ∅ ∨ s = {true} ∨ s = {false} ∨ s = {true, false} := by
+lemma _root_.Bool.cases_set_bool (s : Set Bool) :
+    s = ∅ ∨ s = {true} ∨ s = {false} ∨ s = {true, false} := by
   by_cases h1 : true ∈ s <;> by_cases h2 : false ∈ s
   · refine Or.inr (Or.inr (Or.inr ?_))
     ext x
@@ -272,7 +273,7 @@ lemma mem_set_bool (s : Set Bool) : s = ∅ ∨ s = {true} ∨ s = {false} ∨ s
 lemma _root_.MeasureTheory.Measure.measure_bool_ext {π₁ π₂ : Measure Bool}
     (h_false : π₁ {false} = π₂ {false}) (h_true : π₁ {true} = π₂ {true}) : π₁ = π₂ := by
   ext s
-  obtain (rfl | rfl | rfl | rfl) := mem_set_bool s
+  obtain (rfl | rfl | rfl | rfl) := Bool.cases_set_bool s
     <;> try simp only [measure_empty, h_true, h_false]
   rw [Set.insert_eq, measure_union, measure_union, h_true, h_false] <;> simp
 
@@ -356,9 +357,9 @@ lemma bayesBinaryRisk_dirac (a b : ℝ≥0∞) (x : 𝒳) (π : Measure Bool) :
 
 lemma bayesBinaryRisk_le_min (μ ν : Measure 𝒳) (π : Measure Bool) :
     bayesBinaryRisk μ ν π ≤ min (π {false} * μ Set.univ) (π {true} * ν Set.univ) := by
-  let η : kernel 𝒳 Unit := kernel.const 𝒳 (Measure.dirac ())
+  let η : kernel 𝒳 Unit := kernel.discard 𝒳
   convert bayesBinaryRisk_le_bayesBinaryRisk_comp μ ν π η
-  simp_rw [η, Measure.comp_const, bayesBinaryRisk_dirac]
+  simp_rw [η, Measure.comp_discard, bayesBinaryRisk_dirac]
 
 lemma bayesBinaryRisk_symm (μ ν : Measure 𝒳) (π : Measure Bool) :
     bayesBinaryRisk μ ν π = bayesBinaryRisk ν μ (π.map Bool.not) := by

--- a/TestingLowerBounds/Testing/Binary.lean
+++ b/TestingLowerBounds/Testing/Binary.lean
@@ -250,38 +250,154 @@ lemma bayesBinaryRisk_eq (μ ν : Measure 𝒳) (π : Measure Bool) :
   rw [bayesianRisk, lintegral_fintype, mul_comm (π {false}), mul_comm (π {true})]
   simp
 
+variable {π : Measure Bool}
+
+--rename this and put it in a better place
+lemma mem_set_bool (s : Set Bool) : s = ∅ ∨ s = {true} ∨ s = {false} ∨ s = {true, false} := by
+  by_cases h1 : true ∈ s <;> by_cases h2 : false ∈ s
+  · refine Or.inr (Or.inr (Or.inr ?_))
+    ext x
+    induction x <;> simp [h1, h2]
+  · refine Or.inr (Or.inl ?_)
+    ext x
+    induction x <;> simp [h1, h2]
+  · refine Or.inr (Or.inr (Or.inl ?_))
+    ext x
+    induction x <;> simp [h1, h2]
+  · left
+    ext x
+    induction x <;> simp [h1, h2]
+
+@[ext]
+lemma _root_.MeasureTheory.Measure.measure_bool_ext {π₁ π₂ : Measure Bool}
+    (h_false : π₁ {false} = π₂ {false}) (h_true : π₁ {true} = π₂ {true}) : π₁ = π₂ := by
+  ext s
+  obtain (rfl | rfl | rfl | rfl) := mem_set_bool s
+    <;> try simp only [measure_empty, h_true, h_false]
+  rw [Set.insert_eq, measure_union, measure_union, h_true, h_false] <;> simp
+
+section BoolMeasure
+--maybe it could be useful to have a notation for the construction of a measure on bool from the two values, for example:
+noncomputable
+def boolMeasure (a b : ℝ≥0∞) : Measure Bool := a • Measure.dirac false + b • Measure.dirac true
+
+@[simp]
+lemma boolMeasure_apply_false (a b : ℝ≥0∞) : boolMeasure a b {false} = a := by simp [boolMeasure]
+
+@[simp]
+lemma boolMeasure_apply_true (a b : ℝ≥0∞) : boolMeasure a b {true} = b := by simp [boolMeasure]
+
+lemma measure_eq_boolMeasure (π : Measure Bool) : π = boolMeasure (π {false}) (π {true}) := by
+  ext <;> simp
+
+lemma boolMeasure_withDensity (π : Measure Bool) (f : Bool → ℝ≥0∞) :
+    π.withDensity f = boolMeasure (f false * π {false}) (f true * π {true}) := by
+  ext <;> simp [lintegral_dirac, mul_comm]
+
+end BoolMeasure
+
+/-- `B (a•μ, b•ν; π) = B (μ, ν; (a*π₀, b*π₁)).` -/
+lemma bayesBinaryRisk_smul_smul (μ ν : Measure 𝒳) (π : Measure Bool) (a b : ℝ≥0∞) :
+    bayesBinaryRisk (a • μ) (b • ν) π
+      = bayesBinaryRisk μ ν (π.withDensity (fun x ↦ bif x then b else a)) := by
+  simp [bayesBinaryRisk_eq, Measure.comp_smul_left, lintegral_dirac, mul_assoc]
+
+lemma bayesBinaryRisk_eq_bayesBinaryRisk_one_one (μ ν : Measure 𝒳) (π : Measure Bool) :
+    bayesBinaryRisk μ ν π = bayesBinaryRisk (π {false} • μ) (π {true} • ν) (boolMeasure 1 1) := by
+  rw [bayesBinaryRisk_smul_smul, measure_eq_boolMeasure π, boolMeasure_withDensity]
+  simp
+
 /-- **Data processing inequality** for the Bayes binary risk. -/
 lemma bayesBinaryRisk_le_bayesBinaryRisk_comp (μ ν : Measure 𝒳) (π : Measure Bool)
     (η : kernel 𝒳 𝒳') [IsMarkovKernel η] :
     bayesBinaryRisk μ ν π ≤ bayesBinaryRisk (μ ∘ₘ η) (ν ∘ₘ η) π :=
   (bayesRiskPrior_le_bayesRiskPrior_comp _ _ η).trans_eq (by simp [bayesBinaryRisk])
 
-lemma bayesBinaryRisk_self (μ : Measure 𝒳) (π : Measure Bool) :
-    bayesBinaryRisk μ μ π = min (π {true}) (π {false}) * μ Set.univ := by
-  rw [bayesBinaryRisk_eq]
-  sorry
+lemma nonempty_subtype_isMarkovKernel_of_nonempty {𝒳 : Type*} {m𝒳 : MeasurableSpace 𝒳}
+    {𝒴 : Type*} {m𝒴 : MeasurableSpace 𝒴} [Nonempty 𝒴] :
+    Nonempty (Subtype (@IsMarkovKernel 𝒳 𝒴 m𝒳 m𝒴)) := by
+  simp only [nonempty_subtype, Subtype.exists]
+  let y : 𝒴 := Classical.ofNonempty
+  refine ⟨kernel.const _ (Measure.dirac y), kernel.measurable (kernel.const 𝒳 _), ?_⟩
+  change IsMarkovKernel (kernel.const 𝒳 (Measure.dirac y))
+  exact kernel.isMarkovKernel_const
 
-lemma bayesBinaryRisk_le_min (μ ν : Measure 𝒳) (π : Measure Bool) :
-    bayesBinaryRisk μ ν π ≤ min (π {true} * μ Set.univ) (π {false} * ν Set.univ) := by
-  sorry
+lemma bayesBinaryRisk_self (μ : Measure 𝒳) (π : Measure Bool) :
+    bayesBinaryRisk μ μ π = min (π {false}) (π {true}) * μ Set.univ := by
+  rw [bayesBinaryRisk_eq]
+  refine le_antisymm ?_ ?_
+  · let η : kernel 𝒳 Bool :=
+      if π {true} ≤ π {false} then (kernel.const 𝒳 (Measure.dirac false))
+        else (kernel.const 𝒳 (Measure.dirac true))
+    convert iInf_le_of_le η ?_
+    simp_rw [η]
+    convert iInf_le ?_ ?_ using 1
+    · split_ifs with h <;> simp [le_of_not_ge, h]
+    · split_ifs <;> exact kernel.isMarkovKernel_const
+  · calc
+      _ ≥ ⨅ κ, ⨅ (_ : IsMarkovKernel κ), min (π {false}) (π {true}) * (μ ∘ₘ κ) {false}
+          + min (π {false}) (π {true}) * (μ ∘ₘ κ) {true} := by
+        gcongr <;> simp
+      _ = ⨅ κ, ⨅ (_ : IsMarkovKernel κ), min (π {false}) (π {true}) * μ Set.univ := by
+        simp_rw [← mul_add, ← measure_union (show Disjoint {false} {true} from by simp)
+          (by trivial), (set_fintype_card_eq_univ_iff ({false} ∪ {true})).mp rfl,
+          Measure.comp_apply_univ]
+        rfl
+      _ = _ := by
+        rw [iInf_subtype']
+        convert iInf_const
+        exact nonempty_subtype_isMarkovKernel_of_nonempty
 
 lemma bayesBinaryRisk_dirac (a b : ℝ≥0∞) (x : 𝒳) (π : Measure Bool) :
     bayesBinaryRisk (a • Measure.dirac x) (b • Measure.dirac x) π
-      = min (π {true} * b) (π {false} * a) := by
-  rw [bayesBinaryRisk_eq]
-  have (κ : kernel 𝒳 Bool) [IsMarkovKernel κ] :
-      π {true} * ((b • Measure.dirac x) ∘ₘ κ) {false}
-        + π {false} * ((a • Measure.dirac x) ∘ₘ κ) {true}
-      = (π {true} * b) * κ x {false} + (π {false} * a) * κ x {true} := by
-    have (b : ℝ≥0∞) : (b • Measure.dirac x) ∘ₘ κ = b • κ x := by
-      ext s hs
-      simp only [Measure.bind_apply hs (kernel.measurable _), lintegral_smul_measure,
-        Measure.smul_apply, smul_eq_mul]
-      rw [lintegral_dirac']
-      exact kernel.measurable_coe _ hs
-    simp_rw [this]
-    simp only [Measure.smul_apply, smul_eq_mul, mul_assoc]
-  simp_rw [this]
-  sorry
+      = min (π {false} * a) (π {true} * b) := by
+  rw [bayesBinaryRisk_smul_smul, bayesBinaryRisk_self]
+  simp [lintegral_dirac]
+
+lemma bayesBinaryRisk_le_min (μ ν : Measure 𝒳) (π : Measure Bool) :
+    bayesBinaryRisk μ ν π ≤ min (π {false} * μ Set.univ) (π {true} * ν Set.univ) := by
+  let η : kernel 𝒳 Unit := kernel.const 𝒳 (Measure.dirac ())
+  convert bayesBinaryRisk_le_bayesBinaryRisk_comp μ ν π η
+  simp_rw [η, Measure.comp_const, bayesBinaryRisk_dirac]
+
+lemma bayesBinaryRisk_symm (μ ν : Measure 𝒳) (π : Measure Bool) :
+    bayesBinaryRisk μ ν π = bayesBinaryRisk ν μ (π.map Bool.not) := by
+  have : (Bool.not ⁻¹' {true}) = {false} := by ext x; simp
+  have h1 : (Measure.map Bool.not π) {true} = π {false} := by
+    rw [Measure.map_apply (by exact fun _ a ↦ a) (by trivial), this]
+  have : (Bool.not ⁻¹' {false}) = {true} := by ext x; simp
+  have h2 : (Measure.map Bool.not π) {false} = π {true} := by
+    rw [Measure.map_apply (by exact fun _ a ↦ a) (by trivial), this]
+  simp_rw [bayesBinaryRisk_eq, h1, h2, add_comm, iInf_subtype']
+  -- from this point on the proof is basically a change of variable inside the iInf, to do this I define an equivalence between `Subtype IsMarkovKernel` and itself through the `Bool.not` operation, maybe it can be shortened or something can be separated as a different lemma, but I'm not sure how useful this would be
+  let e : (kernel 𝒳 Bool) ≃ (kernel 𝒳 Bool) := by
+    have h_id : kernel.comap (kernel.deterministic Bool.not (fun _ a ↦ a)) Bool.not (fun _ a ↦ a)
+        = kernel.id := by
+      ext x : 1
+      simp_rw [kernel.comap_apply, kernel.deterministic_apply, kernel.id_apply, Bool.not_not]
+    refine ⟨fun κ ↦ (kernel.deterministic Bool.not (fun _ a ↦ a)) ∘ₖ κ,
+      fun κ ↦ (kernel.deterministic Bool.not (fun _ a ↦ a)) ∘ₖ κ, fun κ ↦ ?_, fun κ ↦ ?_⟩ <;>
+    · dsimp
+      ext x : 1
+      rw [← kernel.comp_assoc, kernel.comp_deterministic_eq_comap, h_id, kernel.id_comp]
+  let e' : (Subtype (@IsMarkovKernel 𝒳 Bool _ _)) ≃ (Subtype (@IsMarkovKernel 𝒳 Bool _ _)) := by
+    refine ⟨fun ⟨κ, _⟩ ↦ ⟨e κ, ?_⟩, fun ⟨κ, _⟩ ↦ ⟨e.symm κ, ?_⟩, fun κ ↦ by simp, fun κ ↦ by simp⟩
+      <;> simp only [Equiv.coe_fn_mk, Equiv.coe_fn_symm_mk, e] <;> infer_instance
+  rw [← Equiv.iInf_comp e']
+  congr with κ
+  simp only [Equiv.coe_fn_mk, Equiv.coe_fn_symm_mk, MeasurableSpace.measurableSet_top, e', e]
+  have h3 b : Set.indicator {true} (1 : Bool → ℝ≥0∞) b.not = Set.indicator {false} 1 b := by
+    cases b <;> simp
+  have h4 b : Set.indicator {false} (1 : Bool → ℝ≥0∞) b.not = Set.indicator {true} 1 b := by
+    cases b <;> simp
+  congr 2 <;>
+  · rw [Measure.bind_apply (by trivial) (kernel.measurable _),
+      Measure.bind_apply (by trivial) (kernel.measurable _)]
+    congr with x
+    rw [kernel.comp_apply']
+    simp only [Measure.dirac_apply' _ (show MeasurableSet {true} by trivial),
+      Measure.dirac_apply' _ (show MeasurableSet {false} by trivial), kernel.deterministic_apply]
+    swap; trivial
+    simp [h3, h4]
 
 end ProbabilityTheory

--- a/blueprint/src/sections/risk.tex
+++ b/blueprint/src/sections/risk.tex
@@ -304,8 +304,8 @@ The following is a new definition, which is a natural generalization of the DeGr
 
 \begin{definition}
   \label{def:riskIncrease}
-  %\lean{}
-  %\leanok
+  \lean{ProbabilityTheory.bayesRiskIncrease}
+  \leanok
   \uses{def:bayesRisk}
   The Bayes risk increase $I^P_{\pi}(\kappa)$ of a kernel $\kappa : \mathcal X \rightsquigarrow \mathcal X'$ with respect to the estimation problem $(P, y, \ell')$ and the prior $\pi \in \mathcal M(\Theta)$ is the difference of the Bayes risk of $(\kappa \circ P, y, \ell')$ and that of $(P, y, \ell')$. That is,
   \begin{align*}
@@ -337,14 +337,14 @@ Use Theorem~\ref{thm:data_proc_bayesRisk}.
 
 \begin{lemma}
   \label{lem:riskIncrease_comp}
-  %\lean{}
-  %\leanok
+  \lean{ProbabilityTheory.bayesRiskIncrease_comp}
+  \leanok
   \uses{def:riskIncrease}
   For $\kappa : \mathcal X \rightsquigarrow \mathcal X'$ and $\eta : \mathcal X' \rightsquigarrow \mathcal X''$ two Markov kernels,
   $I^P_\pi(\eta \circ \kappa) = I^P_\pi(\kappa) + I^{\kappa \circ P}_\pi(\eta)$~.
 \end{lemma}
 
-\begin{proof}%\leanok
+\begin{proof}\leanok
 \uses{}
 \begin{align*}
 I^P_\pi(\kappa) + I^{\kappa \circ P}_\pi(\eta)
@@ -392,8 +392,8 @@ In this section, for a measure $\xi$ on $\{0,1\}$, we write $\xi_0$ for $\xi(\{0
 
 \begin{lemma}
   \label{lem:bayesInv_binary}
-  %\lean{}
-  %\leanok
+  \lean{ProbabilityTheory.bayesInv_twoHypKernel}
+  \leanok
   \uses{def:bayesInv}
   The Bayesian inverse of a kernel $P : \{0,1\} \rightsquigarrow \mathcal X$ with respect to a prior $\xi \in \mathcal M(\{0,1\})$ is $P_\xi^\dagger(x) = \left(\xi_0\frac{d P(0)}{d(P \circ \xi)}(x), \xi_1\frac{d P(1)}{d(P \circ \xi)}(x)\right)$ (almost surely w.r.t. $P \circ \xi = \xi_0 P(0) + \xi_1 P(1)$).
 \end{lemma}
@@ -444,13 +444,13 @@ Thanks to the following lemma, we can prove properties of the Bayes binary risk 
 
 \begin{lemma}
   \label{lem:bayesBinaryRisk_mul}
-  %\lean{}
-  %\leanok
+  \lean{ProbabilityTheory.bayesBinaryRisk_smul_smul}
+  \leanok
   \uses{def:bayesRisk}
   For all $a, b > 0$, $\mathcal B_\xi(\mu, \nu) = \mathcal B_{(a \xi_0, b \xi_1)}(a^{-1} \mu, b^{-1} \nu)$~.
 \end{lemma}
 
-\begin{proof}%\leanok
+\begin{proof}\leanok
 \uses{}
 
 \end{proof}
@@ -459,17 +459,41 @@ Alternatively, we can reduce the study of the Bayes binary risk for any prior to
 
 \begin{lemma}
   \label{lem:bayesBinaryRisk_one_one}
-  %\lean{}
-  %\leanok
+  \lean{ProbabilityTheory.bayesBinaryRisk_eq_bayesBinaryRisk_one_one}
+  \leanok
   \uses{def:bayesRisk}
   $\mathcal B_\xi(\mu, \nu) = \mathcal B_{(1,1)}(\xi_0\mu, \xi_1\nu)$~.
 \end{lemma}
 
-\begin{proof}%\leanok
-\uses{}
+\begin{proof}\leanok
+\uses{ProbabilityTheory.bayesBinaryRisk_smul_smul}
 
 \end{proof}
 
+\begin{theorem}[Data-processing inequality]
+  \label{thm:data_proc_bayesBinaryRisk}
+  \lean{ProbabilityTheory.bayesBinaryRisk_le_bayesBinaryRisk_comp}
+  \leanok
+  \uses{def:bayesBinaryRisk}
+  For $\mu, \nu \in \mathcal M(\mathcal X)$ and $\kappa : \mathcal X \rightsquigarrow \mathcal Y$ a Markov kernel, $\mathcal B_\xi(\kappa \circ \mu, \kappa \circ \nu) \ge \mathcal B_\xi(\mu, \nu)$~.
+\end{theorem}
+
+\begin{proof}\leanok
+\uses{thm:data_proc_bayesRisk}
+Apply Theorem~\ref{thm:data_proc_bayesRisk}.
+\end{proof}
+
+\begin{lemma}
+  \label{lem:bayesBinaryRisk_self}
+  \lean{ProbabilityTheory.bayesBinaryRisk_self}
+  \leanok
+  \uses{def:bayesBinaryRisk}
+  For $\mu \in \mathcal M(\mathcal X)$, $\mathcal B_\xi(\mu, \mu) = \min\{\xi_0, \xi_1\} \mu(\mathcal X)$~.
+\end{lemma}
+
+\begin{proof}\leanok
+\uses{}
+\end{proof}
 
 \begin{lemma}
   \label{lem:bayesBinaryRisk_nonneg}
@@ -492,59 +516,37 @@ It is an infimum of non-negative values.
   For all measures $\mu, \nu$, $\mathcal B_\xi(\mu, \nu) \le \min\{\xi_0 \mu(\mathcal X), \xi_1 \nu(\mathcal X)\}$~.
 \end{lemma}
 
-\begin{proof}%\leanok
-\uses{}
-Since $\mathcal B_\xi(\mu, \nu)$ is an infimum over estimators, we can find an upper bound by choosing an estimator.
-We choose for $\hat{y}$ a constant estimator, with value 1 if $\xi_1 \nu(\mathcal X)\xi_1 > \xi_0 \mu(\mathcal X)$ and 0 otherwise.
-That estimator has Bayesian risk $\min\{\xi_0 \mu(\mathcal X), \xi_1 \nu(\mathcal X)\}$.
-\end{proof}
-
-\begin{lemma}
-  \label{lem:bayesBinaryRisk_self}
-  \lean{ProbabilityTheory.bayesBinaryRisk_self}
-  \leanok
-  \uses{def:bayesBinaryRisk}
-  For $\mu \in \mathcal M(\mathcal X)$, $\mathcal B_\xi(\mu, \mu) = \min\{\xi_0, \xi_1\} \mu(\mathcal X)$~.
-\end{lemma}
-
-\begin{proof}%\leanok
-\uses{lem:bayesBinaryRisk_le}
+\begin{proof}\leanok
+\uses{thm:data_proc_bayesBinaryRisk, lem:bayesBinaryRisk_self, lem:bayesBinaryRisk_mul}
+Let $d_{\mathcal X} : \mathcal X \rightsquigarrow *$ be the discard kernel and $\delta_*$ be the only probability measure over $*$, that is a Dirac delta.
+Then applying the DPI (Theorem~\ref{thm:data_proc_bayesBinaryRisk}), followed by Lemma~\ref{lem:bayesBinaryRisk_mul} and Lemma~\ref{lem:bayesBinaryRisk_self}, we obtain:
 \begin{align*}
-  \mathcal B_\xi(\mu, \mu) &= \inf_{\hat{y} : \mathcal X \rightsquigarrow \{0,1\}}\left(\xi_0 (\hat{y} \circ \mu)(\{1\}) + \xi_1 (\hat{y} \circ \mu)(\{0\})\right) \\
-  &\ge \inf_{\hat{y} : \mathcal X \rightsquigarrow \{0,1\}}\left(\min\{\xi_0, \xi_1\} (\hat{y} \circ \mu)(\{1\}) + \min\{\xi_0, \xi_1\} (\hat{y} \circ \mu)(\{0\})\right) \\
-  &= \inf_{\hat{y} : \mathcal X \rightsquigarrow \{0,1\}}\left(\min\{\xi_0, \xi_1\} (\hat{y} \circ \mu)(\{0, 1\})\right) \\
-  &= \inf_{\hat{y} : \mathcal X \rightsquigarrow \{0,1\}}\left(\min\{\xi_0, \xi_1\} \mu (\mathcal X)\right) \\
-  &= \min\{\xi_0, \xi_1\} \mu (\mathcal X)
+\mathcal B_\xi(\mu, \nu)
+&\le \mathcal B_\xi(d_{\mathcal X} \circ \mu, d_{\mathcal X} \circ \nu)
+\\
+&= \mathcal B_\xi(\mu(\mathcal X) \delta_*, \nu(\mathcal X) \delta_*)
+\\
+&= \mathcal B_{(\mu(\mathcal X) \xi_0, \nu(\mathcal X) \xi_1)}(\delta_*, \delta_*)
+\\
+&= \min\{\mu(\mathcal X) \xi_0, \nu(\mathcal X) \xi_1\} \delta_*(\mathcal X)
+\\
+&= \min\{\mu(\mathcal X) \xi_0, \nu(\mathcal X) \xi_1\}
+\: .
 \end{align*}
-Then we conclude using Lemma~\ref{lem:bayesBinaryRisk_le}.
-
 \end{proof}
 
 \begin{lemma}
   \label{lem:bayesBinaryRisk_symm}
-  %\lean{}
-  %\leanok
+  \lean{ProbabilityTheory.bayesBinaryRisk_symm}
+  \leanok
   \uses{def:bayesBinaryRisk}
   For $\mu, \nu \in \mathcal M(\mathcal X)$ and $\xi \in \mathcal M(\{0,1\})$, $\mathcal B_\xi(\mu, \nu) = \mathcal B_{\xi_{\leftrightarrow}}(\nu, \mu)$ where $\xi_{\leftrightarrow} \in \mathcal M(\{0,1\})$ is such that $\xi_{\leftrightarrow}(\{0\}) = \xi_1$ and $\xi_{\leftrightarrow}(\{1\}) = \xi_0$.
   For $\pi \in [0,1]$, $B_\pi(\mu, \nu) = B_{1 - \pi}(\nu, \mu)$~.
 \end{lemma}
 
-\begin{proof}%\leanok
+\begin{proof}\leanok
 \uses{}
 
-\end{proof}
-
-\begin{theorem}[Data-processing inequality]
-  \label{thm:data_proc_bayesBinaryRisk}
-  \lean{ProbabilityTheory.bayesBinaryRisk_le_bayesBinaryRisk_comp}
-  \leanok
-  \uses{def:bayesBinaryRisk}
-  For $\mu, \nu \in \mathcal M(\mathcal X)$ and $\kappa : \mathcal X \rightsquigarrow \mathcal Y$ a Markov kernel, $\mathcal B_\xi(\kappa \circ \mu, \kappa \circ \nu) \ge \mathcal B_\xi(\mu, \nu)$~.
-\end{theorem}
-
-\begin{proof}\leanok
-\uses{thm:data_proc_bayesRisk}
-Apply Theorem~\ref{thm:data_proc_bayesRisk}.
 \end{proof}
 
 \begin{lemma}


### PR DESCRIPTION
- Add lemmas about the composition and compProd of a mesaure and a kernel, in particular: `Measure.comp_const`, `Measure.compProd_apply_univ`, `Measure.comp_apply_univ`, `Measure.compProd_smul_left`, `Measure.comp_smul_left`
- Remove a duplicate lemma `compProd_const` (there is already `Measure.compProd_const` in the same file)
- Add `mem_set_bool` and the ext lemma `MeasureTheory.Measure.measure_bool_ext`
- Add `boolMeasure` and some API lemmas (for now I am keeping it, it is used only in `bayesBinaryRisk_eq_bayesBinaryRisk_one_one`, but it may be useful in the future)
- Add `nonempty_subtype_isMarkovKernel_of_nonempty` (this is an auxiliary lemma I use it in the proof of `bayesBinaryRisk_self`, but it may be useful other times to handle the iInf in the definition of `bayesBinaryRisk`)
- Add lemmas about the `bayesBinaryRisk`: `bayesBinaryRisk_smul_smul`, `bayesBinaryRisk_eq_bayesBinaryRisk_one_one`, `bayesBinaryRisk_le_min`, `bayesBinaryRisk_symm`
- Finish proof of `bayesBinaryRisk_self`
- Simplify proof of `bayesBinaryRisk_dirac`
- Update blueprint, also change the order of `thm:data_proc_bayesBinaryRisk`, `lem:bayesBinaryRisk_self` and `lem:bayesBinaryRisk_le` and chenge the proof of `lem:bayesBinaryRisk_le` to better reflect the structure of the lean proofs