### PR TITLE
Add lemmas about operations on kernels: `swap`, `parallelComp` and `prod`

### DIFF
--- a/TestingLowerBounds/Kernel/Basic.lean
+++ b/TestingLowerBounds/Kernel/Basic.lean
@@ -50,4 +50,11 @@ lemma deterministic_prod_deterministic {f : α → β} {g : α → γ}
   simp_rw [prod_apply, deterministic_apply]
   rw [Measure.dirac_prod_dirac]
 
+lemma deterministic_comp_deterministic {f : α → β} {g : β → γ}
+    (hf : Measurable f) (hg : Measurable g) :
+    (kernel.deterministic g hg) ∘ₖ (kernel.deterministic f hf) = kernel.deterministic (g ∘ f) (hg.comp hf) := by
+  ext a
+  simp_rw [kernel.comp_deterministic_eq_comap, comap_apply, deterministic_apply]
+  rfl
+
 end ProbabilityTheory.kernel

--- a/TestingLowerBounds/Kernel/Monoidal.lean
+++ b/TestingLowerBounds/Kernel/Monoidal.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Rémy Degenne, Lorenzo Luccioli
 -/
 import Mathlib.Probability.Kernel.Composition
+import TestingLowerBounds.Kernel.Basic
 
 /-!
 
@@ -119,9 +120,8 @@ lemma swap_copy : (swap α α) ∘ₖ (copy α) = copy α := by
 
 @[simp]
 lemma swap_swap : (swap α β) ∘ₖ (swap β α) = kernel.id := by
-  ext ab s hs
-  rw [comp_apply, Measure.bind_apply hs (kernel.measurable _), id_apply, swap_apply,
-    lintegral_dirac' _ (kernel.measurable_coe _ hs), swap_apply, Prod.swap_swap]
+  simp_rw [swap, kernel.deterministic_comp_deterministic, Prod.swap_swap_eq]
+  rfl
 
 end Swap
 


### PR DESCRIPTION
- Add `swap_swap`
- Golf proof of `swap_parallelComp`
- Add `measurable_kernel_prod_mk_left''`
- Add `parallelComp_comp_parallelComp` and some corollaries
- Add `swap_prod`
- Add the section `ParallelComp`