### PR TITLE
Add lemmas about the Bayes binary risk

### DIFF
--- a/TestingLowerBounds/ForMathlib/KernelConstComp.lean
+++ b/TestingLowerBounds/ForMathlib/KernelConstComp.lean
@@ -1,0 +1,24 @@
+import Mathlib.Probability.Kernel.Composition
+
+open MeasureTheory
+
+namespace ProbabilityTheory.kernel
+
+variable {α β ι : Type*} {mα : MeasurableSpace α} {mβ : MeasurableSpace β}
+variable {γ : Type*} {mγ : MeasurableSpace γ}
+
+--TODO: PR this to mathlib, after `comp_deterministic_eq_comap`
+-- #check comp_deterministic_eq_comap
+
+lemma const_comp (μ : Measure γ) (κ : kernel α β) :
+    const β μ ∘ₖ κ = fun a ↦ (κ a) Set.univ • μ := by
+  ext _ _ hs
+  simp_rw [comp_apply' _ _ _ hs, const_apply, MeasureTheory.lintegral_const, Measure.smul_apply,
+    smul_eq_mul, mul_comm]
+
+@[simp]
+lemma const_comp' (μ : Measure γ) (κ : kernel α β) [IsMarkovKernel κ] :
+    const β μ ∘ₖ κ = const α μ := by
+  ext; simp_rw [const_comp, measure_univ, one_smul, const_apply]
+
+end ProbabilityTheory.kernel

--- a/TestingLowerBounds/ForMathlib/MaxMinEqAbs.lean
+++ b/TestingLowerBounds/ForMathlib/MaxMinEqAbs.lean
@@ -1,0 +1,13 @@
+import Mathlib.Algebra.Lie.OfAssociative
+
+--PR this to mathlib
+--the hp LinearOrderedField may not be optimal
+variable {α : Type*} [LinearOrderedField α]
+
+lemma max_eq_add_add_abs_sub (a b : α) : max a b = 2⁻¹  * (a + b + |a - b|) := by
+  rw [← max_add_min a, ← max_sub_min_eq_abs', add_sub_left_comm, add_sub_cancel_right]
+  ring
+
+lemma min_eq_add_sub_abs_sub (a b : α) : min a b = 2⁻¹ * (a + b - |a - b|) := by
+  rw [← min_add_max a, ← max_sub_min_eq_abs', add_sub_assoc, sub_sub_cancel]
+  ring

--- a/TestingLowerBounds/Testing/Binary.lean
+++ b/TestingLowerBounds/Testing/Binary.lean
@@ -7,6 +7,7 @@ import TestingLowerBounds.Testing.Risk
 import TestingLowerBounds.MeasureCompProd
 import Mathlib.Probability.ProbabilityMassFunction.Constructions
 import TestingLowerBounds.BayesInv
+import TestingLowerBounds.ForMathlib.MaxMinEqAbs
 
 /-!
 # Simple Bayesian binary hypothesis testing
@@ -79,6 +80,17 @@ lemma measure_comp_twoHypKernel (μ ν : Measure 𝒳) (π : Measure Bool) :
     Bool.true_eq_false, not_false_eq_true, Finset.sum_insert, cond_true, Finset.sum_singleton,
     cond_false, Measure.coe_add, Measure.coe_smul, Pi.add_apply, Pi.smul_apply, smul_eq_mul]
   congr 1 <;> rw [mul_comm]
+
+lemma absolutelyContinuous_measure_comp_twoHypKernel_left (μ ν : Measure 𝒳)
+    {π : Measure Bool} (hπ : π {false} ≠ 0) :
+    μ ≪ π ∘ₘ twoHypKernel μ ν :=
+  measure_comp_twoHypKernel _ _ _ ▸ add_comm _ (π {true} • ν) ▸
+    (Measure.absolutelyContinuous_smul hπ).add_right _
+
+lemma absolutelyContinuous_measure_comp_twoHypKernel_right (μ ν : Measure 𝒳)
+    {π : Measure Bool} (hπ : π {true} ≠ 0) :
+    ν ≪ π ∘ₘ twoHypKernel μ ν :=
+  measure_comp_twoHypKernel _ _ _ ▸ (Measure.absolutelyContinuous_smul hπ).add_right _
 
 lemma sum_smul_rnDeriv_twoHypKernel (μ ν : Measure 𝒳) [IsFiniteMeasure μ] [IsFiniteMeasure ν]
     (π : Measure Bool) [IsFiniteMeasure π] :
@@ -330,9 +342,9 @@ lemma bayesBinaryRisk_self (μ : Measure 𝒳) (π : Measure Bool) :
   · let η : kernel 𝒳 Bool :=
       if π {true} ≤ π {false} then (kernel.const 𝒳 (Measure.dirac false))
         else (kernel.const 𝒳 (Measure.dirac true))
-    convert iInf_le_of_le η ?_
+    refine iInf_le_of_le η ?_
     simp_rw [η]
-    convert iInf_le ?_ ?_ using 1
+    convert iInf_le _ ?_ using 1
     · split_ifs with h <;> simp [le_of_not_ge, h]
     · split_ifs <;> exact kernel.isMarkovKernel_const
   · calc
@@ -359,6 +371,18 @@ lemma bayesBinaryRisk_le_min (μ ν : Measure 𝒳) (π : Measure Bool) :
     bayesBinaryRisk μ ν π ≤ min (π {false} * μ Set.univ) (π {true} * ν Set.univ) := by
   convert bayesBinaryRisk_le_bayesBinaryRisk_comp μ ν π (kernel.discard 𝒳)
   simp_rw [Measure.comp_discard, bayesBinaryRisk_dirac]
+
+lemma bayesBinaryRisk_of_measure_true_eq_zero (μ ν : Measure 𝒳) (hπ : π {true} = 0) :
+    bayesBinaryRisk μ ν π = 0 := by
+  refine le_antisymm ?_ (zero_le _)
+  convert bayesBinaryRisk_le_min μ ν π
+  simp [hπ]
+
+lemma bayesBinaryRisk_of_measure_false_eq_zero (μ ν : Measure 𝒳) (hπ : π {false} = 0) :
+    bayesBinaryRisk μ ν π = 0 := by
+  refine le_antisymm ?_ (zero_le _)
+  convert bayesBinaryRisk_le_min μ ν π
+  simp [hπ]
 
 lemma bayesBinaryRisk_symm (μ ν : Measure 𝒳) (π : Measure Bool) :
     bayesBinaryRisk μ ν π = bayesBinaryRisk ν μ (π.map Bool.not) := by
@@ -399,5 +423,98 @@ lemma bayesBinaryRisk_symm (μ ν : Measure 𝒳) (π : Measure Bool) :
       Measure.dirac_apply' _ (show MeasurableSet {false} by trivial), kernel.deterministic_apply]
     swap; trivial
     simp [h3, h4]
+
+--TODO: lemma about the generalized bayes estimator for the binary case, we need to define the generalized bayes estimator first in the general case.
+
+lemma bayesBinaryRisk_eq_iInf_measurableSet (μ ν : Measure 𝒳) (π : Measure Bool) :
+    bayesBinaryRisk μ ν π = ⨅ E, ⨅ (_ : MeasurableSet E), π {false} * μ E + π {true} * ν Eᶜ := by
+  apply le_antisymm
+  · simp_rw [le_iInf_iff, bayesBinaryRisk_eq]
+    intro E hE
+    have h_meas : Measurable fun x ↦ Bool.ofNat (E.indicator 1 x) :=
+      (measurable_discrete _).comp' (measurable_one.indicator hE)
+    classical
+    let η : kernel 𝒳 Bool := kernel.deterministic (fun x ↦ Bool.ofNat (E.indicator 1 x)) h_meas
+    refine iInf_le_of_le η ?_
+    convert iInf_le _ (kernel.isMarkovKernel_deterministic _) using 1
+    have h1 : (fun x ↦ Bool.ofNat (E.indicator 1 x)) ⁻¹' {false} = Eᶜ := by
+      ext; simp [Bool.ofNat]
+    have h2 : (fun x ↦ Bool.ofNat (E.indicator 1 x)) ⁻¹' {true} = E := by
+      ext; simp [Bool.ofNat]
+    simp_rw [η, Measure.comp_deterministic_eq_map, Measure.map_apply h_meas trivial, h1, h2,
+      add_comm]
+  · --for this direction we need the generalized bayes estimator for the binary case
+    sorry
+
+--maybe we need some hp to make this work, things may need to be finite
+lemma bayesBinaryRisk_eq_integral_min (μ ν : Measure 𝒳) (π : Measure Bool) :
+    bayesBinaryRisk μ ν π = ∫⁻ x, min (π {false} * μ.rnDeriv (π ∘ₘ twoHypKernel μ ν) x)
+      (π {true} * ν.rnDeriv (π ∘ₘ twoHypKernel μ ν) x) ∂(π ∘ₘ twoHypKernel μ ν) := by
+  --we need the generalized bayes estimator for the binary case
+  sorry
+
+lemma toReal_bayesBinaryRisk_eq_integral_min (μ ν : Measure 𝒳) [SigmaFinite μ] [SigmaFinite ν]
+    (π : Measure Bool) [IsFiniteMeasure π] :
+    (bayesBinaryRisk μ ν π).toReal
+      = ∫ x, min (π {false} * μ.rnDeriv (π ∘ₘ twoHypKernel μ ν) x).toReal
+        (π {true} * ν.rnDeriv (π ∘ₘ twoHypKernel μ ν) x).toReal ∂(π ∘ₘ twoHypKernel μ ν) := by
+  rw [bayesBinaryRisk_eq_integral_min, integral_eq_lintegral_of_nonneg_ae]
+  rotate_left
+  · filter_upwards with x; positivity
+  · refine Measurable.aestronglyMeasurable <| Measurable.min ?_ ?_
+      <;> exact Measure.measurable_rnDeriv _ _ |>.const_mul _ |>.ennreal_toNNReal |>.coe_nnreal_real
+  congr 1
+  apply lintegral_congr_ae
+  filter_upwards [Measure.rnDeriv_ne_top μ _, Measure.rnDeriv_ne_top ν _] with x hxμ hxν
+  have : (π {false} * μ.rnDeriv (π ∘ₘ twoHypKernel μ ν) x) ≠ ⊤ :=
+    (ENNReal.mul_ne_top (measure_ne_top _ _) hxμ)
+  have : (π {true} * ν.rnDeriv (π ∘ₘ twoHypKernel μ ν) x) ≠ ⊤ :=
+    (ENNReal.mul_ne_top (measure_ne_top _ _) hxν)
+  rcases le_total (π {false} * μ.rnDeriv (π ∘ₘ twoHypKernel μ ν) x)
+    (π {true} * ν.rnDeriv (π ∘ₘ twoHypKernel μ ν) x) with h | h
+  all_goals
+  · have h' := (ENNReal.toReal_le_toReal (by assumption) (by assumption)).mpr h
+    simp only [h, h', min_eq_left, min_eq_right]
+    exact (ENNReal.ofReal_toReal_eq_iff.mpr (by assumption)).symm
+
+lemma toReal_bayesBinaryRisk_eq_integral_abs (μ ν : Measure 𝒳) [IsFiniteMeasure μ] [IsFiniteMeasure ν]
+    (π : Measure Bool) [IsFiniteMeasure π] :
+    (bayesBinaryRisk μ ν π).toReal
+      = (2 : ℝ)⁻¹ * (((π ∘ₘ twoHypKernel μ ν) Set.univ).toReal
+        - ∫ x, |(π {false} * μ.rnDeriv (π ∘ₘ twoHypKernel μ ν) x).toReal
+          - (π {true} * ν.rnDeriv (π ∘ₘ twoHypKernel μ ν) x).toReal| ∂(π ∘ₘ twoHypKernel μ ν)) := by
+  rw [toReal_bayesBinaryRisk_eq_integral_min]
+  simp_rw [min_eq_add_sub_abs_sub, integral_mul_left]
+  congr
+  have hμ_int : Integrable (fun x ↦ (π {false} * μ.rnDeriv (π ∘ₘ twoHypKernel μ ν) x).toReal) (π ∘ₘ twoHypKernel μ ν) := by
+    simp_rw [ENNReal.toReal_mul]
+    exact Integrable.const_mul Measure.integrable_toReal_rnDeriv _
+  have hν_int : Integrable (fun x ↦ (π {true} * ν.rnDeriv (π ∘ₘ twoHypKernel μ ν) x).toReal) (π ∘ₘ twoHypKernel μ ν) := by
+    simp_rw [ENNReal.toReal_mul]
+    exact Integrable.const_mul Measure.integrable_toReal_rnDeriv _
+  have h_int_abs : Integrable (fun x ↦ |(π {false} * μ.rnDeriv (π ∘ₘ twoHypKernel μ ν) x).toReal
+      - (π {true} * ν.rnDeriv (π ∘ₘ twoHypKernel μ ν) x).toReal|) (π ∘ₘ twoHypKernel μ ν) :=
+    hμ_int.sub hν_int |>.abs
+  rw [integral_sub _ h_int_abs, integral_add hμ_int hν_int]
+  swap; · exact hμ_int.add hν_int
+  simp only [ENNReal.toReal_mul, MeasurableSet.univ, sub_left_inj, integral_mul_left]
+  nth_rw 5 [measure_comp_twoHypKernel]
+  calc
+    _ = (π {false}).toReal * (μ Set.univ).toReal + (π {true}).toReal
+        * ∫ (a : 𝒳), ((∂ν/∂π ∘ₘ ⇑(twoHypKernel μ ν)) a).toReal ∂π ∘ₘ ⇑(twoHypKernel μ ν) := by
+      by_cases hπ_false : π {false} = 0
+      · simp [hπ_false, bayesBinaryRisk_of_measure_false_eq_zero]
+      rw [Measure.integral_toReal_rnDeriv
+        (absolutelyContinuous_measure_comp_twoHypKernel_left μ ν hπ_false)]
+    _ = (π {false}).toReal * (μ Set.univ).toReal + (π {true}).toReal * (ν Set.univ).toReal := by
+      by_cases hπ_true : π {true} = 0
+      · simp [hπ_true, bayesBinaryRisk_of_measure_true_eq_zero]
+      rw [Measure.integral_toReal_rnDeriv
+        (absolutelyContinuous_measure_comp_twoHypKernel_right μ ν hπ_true)]
+    _ = _ := by
+      simp_rw [add_comm, Measure.coe_add, Measure.coe_smul, Pi.add_apply, Pi.smul_apply,
+        smul_eq_mul, ENNReal.toReal_add (ENNReal.mul_ne_top (measure_ne_top _ _)
+        (measure_ne_top _ _)) (ENNReal.mul_ne_top (measure_ne_top _ _) (measure_ne_top _ _)),
+        ENNReal.toReal_mul]
 
 end ProbabilityTheory

--- a/TestingLowerBounds/Testing/Risk.lean
+++ b/TestingLowerBounds/Testing/Risk.lean
@@ -226,34 +226,6 @@ lemma bayesianRisk_ge_lintegral_iInf_bayesInv [StandardBorelSpace Θ] [Nonempty 
     _ = ⨅ z, ∫⁻ (θ : Θ), E.ℓ (E.y θ, z) ∂(E.P†π) x := by
       rw [lintegral_const, measure_univ, mul_one]
 
-
--- what is the best way to state this lemma about convexity? How should I deal with explicitly suming and multipliying the P of an estimation problem?
---Ideas: define separately P₁, P₂, y, ℓ and then state the lemma usng the constructor for the estimation problem
---Or define the sum and scalar multiplication for estimation problems, then state the lemma using these operations, but we have to choose how to handle the fact that here we only want to sum the P, not the y and ℓ, should we require in the hypothesis of the sum operator that the y and ℓ are the same? But maybe this way it gets hard to use, maybe just use junk values when the y and ℓ are not the same, or just take the y and ℓ from the first estimation problem
-
---for now I will try to implement the first one, it seems more direct, but maybe the second is more elegant in the long run
---I'm having troubles with the first one, it seems we have no scalar multiplication of kernels, should we implement one? Maybe with the ENNReals?
---For now I am leanving this lemma, it is not used in the following ones
-variable (P₁ P₂ : kernel Θ 𝒳) (a : ℝ) (b : ℝ≥0) (c: ℝ≥0∞)
--- #check P₁ + P₂
--- #check a • P₁ --fails
--- #check b • P₁ --fails
--- #check c • P₁ --fails
-
--- lemma bayesRiskPrior_concave (P₁ P₂ : kernel Θ 𝒳) {y : Θ → 𝒴} (y_meas : Measurable y)
---     {ℓ : 𝒴 × 𝒵 → ℝ≥0∞} (ℓ_meas : Measurable ℓ)
---     {a b : ℝ≥0∞} (ha : 0 ≤ a) (hb : 0 ≤ b) (hab : a + b = 1) (π : Measure Θ) :
-
---     0 ≤ bayesRiskPrior ⟨a • P₁ + b • P₂, _, _, _, _⟩ π := by
-
---   sorry
-
-/-! ### Generalized Bayes estimator -/
-
---TODO: how do we define the generalized Bayes estimator?
---maybe we could say that an estimator κ is a generalized Bayes estimator if for every x `P†π(x)[θ ↦ ℓ(y(θ), κ x)] = min_z P†π(x)[θ ↦ ℓ(y(θ), z)]` and then use the hp: `∃κ generalized Bayes estimator`.
-
-
 /-! ### Bayes risk increase -/
 
 noncomputable

--- a/TestingLowerBounds/Testing/Risk.lean
+++ b/TestingLowerBounds/Testing/Risk.lean
@@ -4,6 +4,10 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Rémy Degenne
 -/
 import TestingLowerBounds.ForMathlib.RadonNikodym
+import TestingLowerBounds.ForMathlib.KernelConstComp
+import TestingLowerBounds.MeasureCompProd
+import TestingLowerBounds.BayesInv
+import Mathlib.Probability.Kernel.Invariance
 
 /-!
 # Estimation and risk
@@ -72,6 +76,16 @@ lemma estimationProblem.comp_comp (E : estimationProblem Θ 𝒳 𝒴 𝒵) (κ 
     (η : kernel 𝒳' 𝒳'') [IsSFiniteKernel η] :
     (E.comp κ).comp η = E.comp (η ∘ₖ κ) := by
   ext <;> simp [kernel.comp_assoc]
+
+@[simps]
+noncomputable
+def estimationProblem.compProd (E : estimationProblem Θ 𝒳 𝒴 𝒵) (κ : kernel (Θ × 𝒳) 𝒳') :
+    estimationProblem Θ (𝒳 × 𝒳') 𝒴 𝒵 where
+  P := E.P ⊗ₖ κ
+  y := E.y
+  y_meas := E.y_meas
+  ℓ := E.ℓ
+  ℓ_meas := E.ℓ_meas
 
 end EstimationProblem
 
@@ -153,6 +167,93 @@ lemma bayesRisk_le_minimaxRisk (E : estimationProblem Θ 𝒳 𝒴 𝒵) :
   simp only [bayesRisk, iSup_le_iff]
   exact fun _ _ ↦ bayesRiskPrior_le_minimaxRisk _ _
 
+/-! ### Properties of the Bayes risk of a prior -/
+
+lemma bayesRiskPrior_compProd_le_bayesRiskPrior (E : estimationProblem Θ 𝒳 𝒴 𝒵)
+    [IsSFiniteKernel E.P] (π : Measure Θ)
+    (κ : kernel (Θ × 𝒳) 𝒳') [IsMarkovKernel κ] :
+    bayesRiskPrior (E.compProd κ) π ≤ bayesRiskPrior E π := by
+  have : E = (E.compProd κ).comp (kernel.deterministic (fun (x, _) ↦ x) (by fun_prop)) := by
+    ext
+    · rw [estimationProblem.comp, estimationProblem.compProd, kernel.comp_apply,
+        Measure.comp_deterministic_eq_map, ← kernel.fst_apply, kernel.fst_compProd]
+    rfl; rfl
+  nth_rw 2 [this]
+  exact bayesRiskPrior_le_bayesRiskPrior_comp _ _ _
+
+-- Do we also need a version without the `IsMarkovKernel` assumption? it would be of the form:
+-- `bayesRiskPrior E π ≤ ⨅ z : 𝒵, ∫⁻ θ, E.ℓ (E.y θ, z) * (E.P θ) Set.univ ∂π`
+lemma bayesRiskPrior_le_inf (E : estimationProblem Θ 𝒳 𝒴 𝒵) (π : Measure Θ) [IsMarkovKernel E.P] :
+    bayesRiskPrior E π ≤ ⨅ z : 𝒵, ∫⁻ θ, E.ℓ (E.y θ, z) ∂π := by
+  simp_rw [le_iInf_iff, bayesRiskPrior]
+  refine fun z ↦ iInf_le_of_le (kernel.const _ (Measure.dirac z)) ?_
+  convert iInf_le _ ?_ using 1
+  · simp_rw [bayesianRisk, risk, kernel.const_comp', kernel.const_apply]
+    congr with θ
+    rw [lintegral_dirac']
+    have := E.ℓ_meas
+    fun_prop [E.ℓ_meas]
+  · exact kernel.isMarkovKernel_const
+
+lemma bayesianRisk_eq_bayesInv_prod [StandardBorelSpace Θ] [Nonempty Θ]
+    (E : estimationProblem Θ 𝒳 𝒴 𝒵) [IsMarkovKernel E.P] (κ : kernel 𝒳 𝒵)
+    (π : Measure Θ) [IsFiniteMeasure π] [IsSFiniteKernel κ] :
+    bayesianRisk E κ π = ∫⁻ (θz : Θ × 𝒵), E.ℓ (E.y θz.1, θz.2) ∂(π ∘ₘ (((E.P†π) ×ₖ κ) ∘ₖ E.P)) := by
+  have := E.ℓ_meas
+  have := E.y_meas
+  simp only [bayesianRisk, risk]
+  rw [← MeasureTheory.Measure.lintegral_compProd (f := fun θz ↦ E.ℓ (E.y θz.1, θz.2)) (by fun_prop),
+    ← kernel.swap_prod, kernel.prod_eq_copy_comp_parallelComp, Measure.compProd_eq_comp,
+    kernel.prod_eq_copy_comp_parallelComp]
+  nth_rw 2 [← kernel.parallelComp_comp_id_right_left]
+  simp_rw [← Measure.comp_assoc, compProd_bayesInv'', Measure.comp_assoc, ← kernel.comp_assoc,
+  kernel.swap_parallelComp, kernel.comp_assoc (_ ∥ₖ κ), kernel.swap_parallelComp, kernel.comp_assoc,
+  kernel.swap_copy, ← kernel.comp_assoc, kernel.parallelComp_comp_id_left_left]
+
+lemma bayesianRisk_ge_lintegral_iInf_bayesInv [StandardBorelSpace Θ] [Nonempty Θ]
+    (E : estimationProblem Θ 𝒳 𝒴 𝒵) [IsMarkovKernel E.P] (κ : kernel 𝒳 𝒵)
+    (π : Measure Θ) [IsFiniteMeasure π] [IsMarkovKernel κ] :
+    bayesianRisk E κ π ≥ ∫⁻ x, ⨅ z : 𝒵, ∫⁻ θ, E.ℓ (E.y θ, z) ∂((E.P†π) x) ∂(π ∘ₘ E.P) := by
+  have := E.ℓ_meas
+  have := E.y_meas
+  rw [bayesianRisk_eq_bayesInv_prod, ← Measure.comp_assoc,
+    Measure.lintegral_bind (kernel.measurable ((E.P†π) ×ₖ κ)) (by fun_prop)]
+  gcongr with x
+  rw [kernel.prod_apply, lintegral_prod_symm' _ (by fun_prop)]
+  calc
+    _ ≥ ∫⁻ _, ⨅ z, ∫⁻ (θ : Θ), E.ℓ (E.y θ, z) ∂(E.P†π) x ∂κ x :=
+      lintegral_mono fun z ↦ iInf_le' _ z
+    _ = ⨅ z, ∫⁻ (θ : Θ), E.ℓ (E.y θ, z) ∂(E.P†π) x := by
+      rw [lintegral_const, measure_univ, mul_one]
+
+
+-- what is the best way to state this lemma about convexity? How should I deal with explicitly suming and multipliying the P of an estimation problem?
+--Ideas: define separately P₁, P₂, y, ℓ and then state the lemma usng the constructor for the estimation problem
+--Or define the sum and scalar multiplication for estimation problems, then state the lemma using these operations, but we have to choose how to handle the fact that here we only want to sum the P, not the y and ℓ, should we require in the hypothesis of the sum operator that the y and ℓ are the same? But maybe this way it gets hard to use, maybe just use junk values when the y and ℓ are not the same, or just take the y and ℓ from the first estimation problem
+
+--for now I will try to implement the first one, it seems more direct, but maybe the second is more elegant in the long run
+--I'm having troubles with the first one, it seems we have no scalar multiplication of kernels, should we implement one? Maybe with the ENNReals?
+--For now I am leanving this lemma, it is not used in the following ones
+variable (P₁ P₂ : kernel Θ 𝒳) (a : ℝ) (b : ℝ≥0) (c: ℝ≥0∞)
+-- #check P₁ + P₂
+-- #check a • P₁ --fails
+-- #check b • P₁ --fails
+-- #check c • P₁ --fails
+
+-- lemma bayesRiskPrior_concave (P₁ P₂ : kernel Θ 𝒳) {y : Θ → 𝒴} (y_meas : Measurable y)
+--     {ℓ : 𝒴 × 𝒵 → ℝ≥0∞} (ℓ_meas : Measurable ℓ)
+--     {a b : ℝ≥0∞} (ha : 0 ≤ a) (hb : 0 ≤ b) (hab : a + b = 1) (π : Measure Θ) :
+
+--     0 ≤ bayesRiskPrior ⟨a • P₁ + b • P₂, _, _, _, _⟩ π := by
+
+--   sorry
+
+/-! ### Generalized Bayes estimator -/
+
+--TODO: how do we define the generalized Bayes estimator?
+--maybe we could say that an estimator κ is a generalized Bayes estimator if for every x `P†π(x)[θ ↦ ℓ(y(θ), κ x)] = min_z P†π(x)[θ ↦ ℓ(y(θ), z)]` and then use the hp: `∃κ generalized Bayes estimator`.
+
+
 /-! ### Bayes risk increase -/
 
 noncomputable
@@ -171,5 +272,13 @@ lemma le_bayesRiskIncrease_comp (E : estimationProblem Θ 𝒳 𝒴 𝒵) (π : 
     [IsMarkovKernel κ] (η : kernel 𝒳' 𝒳'') [IsMarkovKernel η] :
     bayesRiskIncrease (E.comp κ) π η ≤ bayesRiskIncrease E π (η ∘ₖ κ) := by
   simp [bayesRiskIncrease_comp]
+
+/-- **Data processing inequality** for the Bayes risk increase. -/
+lemma bayesRiskIncrease_discard_comp_le_bayesRiskIncrease (E : estimationProblem Θ 𝒳 𝒴 𝒵)
+    (π : Measure Θ) (κ : kernel 𝒳 𝒳') [IsMarkovKernel κ] :
+    bayesRiskIncrease (E.comp κ) π (kernel.discard 𝒳')
+      ≤ bayesRiskIncrease E π (kernel.discard 𝒳) := by
+  convert le_bayesRiskIncrease_comp E π κ (kernel.discard 𝒳')
+  simp
 
 end ProbabilityTheory


### PR DESCRIPTION
- Add `MaxMinEqAbs.lean` with two lemmas about the formula for the max and min in terms of the absoulte value of the difference.
- Add `absolutelyContinuous_measure_comp_twoHypKernel_left` and `absolutelyContinuous_measure_comp_twoHypKernel_right`.
- Add `bayesBinaryRisk_of_measure_true_eq_zero` and `bayesBinaryRisk_of_measure_false_eq_zero` to handle the case when `π` is a Dirac delta.
- Add `bayesBinaryRisk_eq_iInf_measurableSet` with partial proof.
- Add statement of `bayesBinaryRisk_eq_iInf_measurableSet`.
- Add `toReal_bayesBinaryRisk_eq_integral_min` and `toReal_bayesBinaryRisk_eq_integral_abs`.
- Cleanup.

Depends on #96.