### PR TITLE
Add lemmas about the Bayes binary risk

### DIFF
--- a/TestingLowerBounds/ForMathlib/MaxMinEqAbs.lean
+++ b/TestingLowerBounds/ForMathlib/MaxMinEqAbs.lean
@@ -1,0 +1,13 @@
+import Mathlib.Algebra.Lie.OfAssociative
+
+--PR this to mathlib
+--the hp LinearOrderedField may not be optimal
+variable {α : Type*} [LinearOrderedField α]
+
+lemma max_eq_add_add_abs_sub (a b : α) : max a b = 2⁻¹  * (a + b + |a - b|) := by
+  rw [← max_add_min a, ← max_sub_min_eq_abs', add_sub_left_comm, add_sub_cancel_right]
+  ring
+
+lemma min_eq_add_sub_abs_sub (a b : α) : min a b = 2⁻¹ * (a + b - |a - b|) := by
+  rw [← min_add_max a, ← max_sub_min_eq_abs', add_sub_assoc, sub_sub_cancel]
+  ring


### PR DESCRIPTION
- Add `MaxMinEqAbs.lean` with two lemmas about the formula for the max and min in terms of the absoulte value of the difference.
- Add `absolutelyContinuous_measure_comp_twoHypKernel_left` and `absolutelyContinuous_measure_comp_twoHypKernel_right`.
- Add `bayesBinaryRisk_of_measure_true_eq_zero` and `bayesBinaryRisk_of_measure_false_eq_zero` to handle the case when `π` is a Dirac delta.
- Add `bayesBinaryRisk_eq_iInf_measurableSet` with partial proof.
- Add statement of `bayesBinaryRisk_eq_iInf_measurableSet`.
- Add `toReal_bayesBinaryRisk_eq_integral_min` and `toReal_bayesBinaryRisk_eq_integral_abs`.
- Cleanup.