### PR TITLE
Add the intergal forms of the `fDiv` of `StatInfoFun`

### DIFF
--- a/TestingLowerBounds/StatInfoFun.lean
+++ b/TestingLowerBounds/StatInfoFun.lean
@@ -5,6 +5,7 @@ Authors: Rémy Degenne, Lorenzo Luccioli
 -/
 import TestingLowerBounds.ForMathlib.ByParts
 import TestingLowerBounds.ForMathlib.LeftRightDeriv
+import TestingLowerBounds.ForMathlib.MaxMinEqAbs
 import Mathlib.MeasureTheory.Integral.FundThmCalculus
 import Mathlib.MeasureTheory.Constructions.Prod.Integral
 
@@ -56,9 +57,9 @@ lemma measurable_statInfoFun2 : Measurable fun γ ↦ statInfoFun β γ x := by
   change Measurable (statInfoFun.uncurry.uncurry ∘ (fun (γ : ℝ) ↦ ((β, γ), x)))
   exact stronglymeasurable_statInfoFun.measurable.comp (by fun_prop)
 
-lemma measurable_statInfoFun3 : Measurable fun x ↦ statInfoFun β γ x := by
-  change Measurable (statInfoFun.uncurry.uncurry ∘ (fun (x : ℝ) ↦ ((β, γ), x)))
-  exact stronglymeasurable_statInfoFun.measurable.comp (by fun_prop)
+lemma stronglyMeasurable_statInfoFun3 : StronglyMeasurable (statInfoFun β γ) := by
+  change StronglyMeasurable (statInfoFun.uncurry.uncurry ∘ (fun (x : ℝ) ↦ ((β, γ), x)))
+  refine stronglymeasurable_statInfoFun.measurable.comp (by fun_prop) |>.stronglyMeasurable
 
 end Measurability
 
@@ -189,19 +190,17 @@ lemma derivAtTop_statInfoFun_of_nonpos_of_gt (hβ : β ≤ 0) (hγ : γ > β) :
   · simp
   exact derivAtTop_of_tendsto (tendsto_statInfoFun_div_at_top_of_neg_of_gt hβ hγ)
 
-lemma derivAtTop_statInfoFun_ne_top (β γ : ℝ) : derivAtTop (fun x ↦ statInfoFun β γ x) ≠ ∞ := by
-  rcases le_total β 0 with (hβ | hβ) <;> by_cases hγ : γ ≤ β
-  · exact derivAtTop_statInfoFun_of_nonpos_of_le hβ hγ ▸ EReal.coe_ne_top _
-  · exact derivAtTop_statInfoFun_of_nonpos_of_gt hβ (lt_of_not_ge hγ) ▸ EReal.coe_ne_top _
-  · exact derivAtTop_statInfoFun_of_nonneg_of_le hβ hγ ▸ EReal.zero_ne_top
-  · exact derivAtTop_statInfoFun_of_nonneg_of_gt hβ (lt_of_not_ge hγ) ▸ EReal.coe_ne_top _
+lemma derivAtTop_statInfoFun_ne_top (β γ : ℝ) : derivAtTop (fun x ↦ statInfoFun β γ x) ≠ ⊤ := by
+  rcases le_total 0 β with (hβ | hβ) <;> rcases le_or_lt γ β with (hγ | hγ) <;>
+    simp [derivAtTop_statInfoFun_of_nonneg_of_le, derivAtTop_statInfoFun_of_nonneg_of_gt,
+      derivAtTop_statInfoFun_of_nonpos_of_le, derivAtTop_statInfoFun_of_nonpos_of_gt, hβ, hγ]
 
 end derivAtTop
 
 lemma integrable_statInfoFun_rnDeriv (β γ : ℝ)
     (μ ν : Measure 𝒳) [IsFiniteMeasure μ] [IsFiniteMeasure ν] :
     Integrable (fun x ↦ statInfoFun β γ ((∂μ/∂ν) x).toReal) ν := by
-  refine integrable_f_rnDeriv_of_derivAtTop_ne_top _ _ measurable_statInfoFun3.stronglyMeasurable
+  refine integrable_f_rnDeriv_of_derivAtTop_ne_top _ _ stronglyMeasurable_statInfoFun3
     ?_ (derivAtTop_statInfoFun_ne_top β γ)
   exact (convexOn_statInfoFun β γ).subset (fun _ _ ↦ trivial) (convex_Ici 0)
 
@@ -340,11 +339,136 @@ end statInfoFun_γ
 section fDiv
 
 lemma nnReal_mul_fDiv {a : NNReal} :
-    a * fDiv (fun x ↦ statInfoFun β γ x) μ ν = fDiv (statInfoFun (a * β) (a * γ)) μ ν := by
+    a * fDiv (statInfoFun β γ) μ ν = fDiv (fun x ↦ statInfoFun (a * β) (a * γ) x) μ ν := by
   change (a.1 : EReal) * _ = _
   rw [← fDiv_mul a.2 ((convexOn_statInfoFun β γ).subset (fun _ _ ↦ trivial) (convex_Ici 0)) μ ν]
   simp_rw [const_mul_statInfoFun a.2]
   rfl
+
+lemma fDiv_statInfoFun_eq_integral_max_of_nonneg_of_le [IsFiniteMeasure μ] [IsFiniteMeasure ν]
+    (hβ : 0 ≤ β) (hγ : γ ≤ β) :
+    fDiv (statInfoFun β γ) μ ν = ∫ x, max 0 (γ - β * ((∂μ/∂ν) x).toReal) ∂ν := by
+  simp_rw [fDiv_of_integrable (integrable_statInfoFun_rnDeriv _ _ _ _),
+    derivAtTop_statInfoFun_of_nonneg_of_le hβ hγ, zero_mul, add_zero, statInfoFun_of_le hγ]
+
+lemma fDiv_statInfoFun_eq_integral_max_of_nonneg_of_gt [IsFiniteMeasure μ] [IsFiniteMeasure ν]
+    (hβ : 0 ≤ β) (hγ : β < γ) :
+    fDiv (statInfoFun β γ) μ ν
+      = ∫ x, max 0 (β * ((∂μ/∂ν) x).toReal - γ) ∂ν + β * (μ.singularPart ν) univ := by
+  simp_rw [fDiv_of_integrable (integrable_statInfoFun_rnDeriv _ _ _ _),
+    derivAtTop_statInfoFun_of_nonneg_of_gt hβ hγ, statInfoFun_of_gt hγ]
+
+lemma fDiv_statInfoFun_eq_integral_max_of_nonpos_of_le [IsFiniteMeasure μ] [IsFiniteMeasure ν]
+    (hβ : β ≤ 0) (hγ : γ ≤ β) :
+    fDiv (statInfoFun β γ) μ ν
+      = ∫ x, max 0 (γ - β * ((∂μ/∂ν) x).toReal) ∂ν - β * (μ.singularPart ν) univ := by
+  simp_rw [fDiv_of_integrable (integrable_statInfoFun_rnDeriv _ _ _ _),
+    derivAtTop_statInfoFun_of_nonpos_of_le hβ hγ, statInfoFun_of_le hγ, neg_mul, ← sub_eq_add_neg]
+
+lemma fDiv_statInfoFun_eq_integral_max_of_nonpos_of_gt [IsFiniteMeasure μ] [IsFiniteMeasure ν]
+    (hβ : β ≤ 0) (hγ : β < γ) :
+    fDiv (statInfoFun β γ) μ ν = ∫ x, max 0 (β * ((∂μ/∂ν) x).toReal - γ) ∂ν := by
+  simp_rw [fDiv_of_integrable (integrable_statInfoFun_rnDeriv _ _ _ _),
+    derivAtTop_statInfoFun_of_nonpos_of_gt hβ hγ, statInfoFun_of_gt hγ, zero_mul, add_zero]
+
+/-- Auxiliary lemma for `fDiv_statInfoFun_eq_integral_abs_of_nonneg_of_le` and
+`fDiv_statInfoFun_eq_integral_abs_of_nonpos_of_le`. -/
+lemma integral_max_eq_integral_abs [IsFiniteMeasure μ] [IsFiniteMeasure ν] :
+    ∫ x, max 0 (γ - β * ((∂μ/∂ν) x).toReal) ∂ν = (2 : ℝ)⁻¹ * (∫ x, |β * ((∂μ/∂ν) x).toReal
+      - γ| ∂ν + γ * (ν univ).toReal - β * (μ univ).toReal
+      + β * ((μ.singularPart ν) univ).toReal) := by
+  simp_rw [max_eq_add_add_abs_sub, zero_add, zero_sub, neg_sub, integral_mul_left]
+  congr
+  have h_int : Integrable (fun x ↦ β * ((∂μ/∂ν) x).toReal) ν :=
+    Measure.integrable_toReal_rnDeriv.const_mul _
+  have h_int' : Integrable (fun x ↦ γ - β * ((∂μ/∂ν) x).toReal) ν := (integrable_const γ).sub h_int
+  rw [integral_add h_int', integral_sub (integrable_const γ) h_int, integral_const, smul_eq_mul,
+    mul_comm, integral_mul_left, add_comm, add_sub_assoc, add_assoc, sub_eq_add_neg, sub_eq_add_neg,
+    add_assoc, ← mul_neg, ← mul_neg, ← mul_add]
+  swap; · exact (integrable_add_const_iff.mpr h_int).abs
+  congr
+  nth_rw 2 [Measure.haveLebesgueDecomposition_add μ ν]
+  simp only [Measure.coe_add, Pi.add_apply, MeasurableSet.univ, withDensity_apply,
+    Measure.restrict_univ]
+  rw [ENNReal.toReal_add (measure_ne_top _ _)]
+  swap; · exact lt_top_iff_ne_top.mp <| (setLIntegral_univ _ ▸
+      Measure.setLIntegral_rnDeriv_le univ).trans_lt IsFiniteMeasure.measure_univ_lt_top
+  ring_nf
+  rw [integral_toReal (Measure.measurable_rnDeriv μ ν).aemeasurable (Measure.rnDeriv_lt_top μ ν)]
+
+/-- Auxiliary lemma for `fDiv_statInfoFun_eq_integral_abs_of_nonneg_of_gt` and
+`fDiv_statInfoFun_eq_integral_abs_of_nonpos_of_gt`. -/
+lemma integral_max_eq_integral_abs' [IsFiniteMeasure μ] [IsFiniteMeasure ν] :
+    ∫ x, max 0 (β * ((∂μ/∂ν) x).toReal - γ) ∂ν = (2 : ℝ)⁻¹ * (∫ x, |β * ((∂μ/∂ν) x).toReal
+      - γ| ∂ν - γ * (ν univ).toReal + β * (μ univ).toReal
+      - β * ((μ.singularPart ν) univ).toReal) := by
+  simp_rw [max_eq_add_add_abs_sub, zero_add, zero_sub, abs_neg, integral_mul_left]
+  congr
+  have h_int : Integrable (fun x ↦ β * ((∂μ/∂ν) x).toReal) ν :=
+    Measure.integrable_toReal_rnDeriv.const_mul _
+  have h_int' : Integrable (fun x ↦ β * ((∂μ/∂ν) x).toReal - γ) ν := h_int.sub (integrable_const γ)
+  rw [integral_add h_int', integral_sub h_int (integrable_const γ), integral_const, smul_eq_mul,
+    mul_comm, integral_mul_left, add_comm, add_sub_assoc, sub_eq_add_neg, add_comm (β * _),
+    ← add_assoc, ← sub_eq_add_neg]
+  swap; · exact (h_int.sub (integrable_const _)).abs
+  congr
+  nth_rw 2 [Measure.haveLebesgueDecomposition_add μ ν]
+  simp only [Measure.coe_add, Pi.add_apply, MeasurableSet.univ, withDensity_apply,
+    Measure.restrict_univ]
+  rw [ENNReal.toReal_add (measure_ne_top _ _)]
+  swap; · exact lt_top_iff_ne_top.mp <| (setLIntegral_univ _ ▸
+      Measure.setLIntegral_rnDeriv_le univ).trans_lt IsFiniteMeasure.measure_univ_lt_top
+  ring_nf
+  rw [integral_toReal (Measure.measurable_rnDeriv μ ν).aemeasurable (Measure.rnDeriv_lt_top μ ν)]
+
+lemma fDiv_statInfoFun_eq_integral_abs_of_nonneg_of_le [IsFiniteMeasure μ] [IsFiniteMeasure ν]
+    (hβ : 0 ≤ β) (hγ : γ ≤ β) :
+    fDiv (statInfoFun β γ) μ ν = (2 : ℝ)⁻¹ * (∫ x, |β * ((∂μ/∂ν) x).toReal - γ| ∂ν
+      + β * (μ.singularPart ν) univ + γ * ν univ - β * μ univ) := by
+  rw [fDiv_statInfoFun_eq_integral_max_of_nonneg_of_le hβ hγ, integral_max_eq_integral_abs,
+    sub_eq_add_neg, add_assoc, add_comm (- _), ← add_assoc, ← sub_eq_add_neg, add_assoc,
+    add_comm (_ * _), add_assoc]
+  simp only [EReal.coe_mul, EReal.coe_sub, EReal.coe_add,
+    EReal.coe_ennreal_toReal (measure_ne_top _ _)]
+
+lemma fDiv_statInfoFun_eq_integral_abs_of_nonneg_of_gt [IsFiniteMeasure μ] [IsFiniteMeasure ν]
+    (hβ : 0 ≤ β) (hγ : β < γ) :
+    fDiv (statInfoFun β γ) μ ν = (2 : ℝ)⁻¹ * (∫ x, |β * ((∂μ/∂ν) x).toReal - γ| ∂ν
+      + β * (μ.singularPart ν) univ + β * μ univ - γ * ν univ) := by
+  have h_eq :
+      (β : EReal) * ((μ.singularPart ν) univ)
+        = ↑(2⁻¹ * (2 * β * ((μ.singularPart ν) univ).toReal)) := by
+    simp [mul_assoc, EReal.coe_ennreal_toReal (measure_ne_top _ _)]
+  rw [fDiv_statInfoFun_eq_integral_max_of_nonneg_of_gt hβ hγ, integral_max_eq_integral_abs', h_eq,
+    ← EReal.coe_add, ← mul_add, EReal.coe_mul]
+  simp_rw [← EReal.coe_ennreal_toReal (measure_ne_top _ _), ← EReal.coe_mul, sub_eq_add_neg,
+    ← EReal.coe_neg, ← EReal.coe_add, add_assoc]
+  congr 3
+  ring
+
+lemma fDiv_statInfoFun_eq_integral_abs_of_nonpos_of_le [IsFiniteMeasure μ] [IsFiniteMeasure ν]
+    (hβ : β ≤ 0) (hγ : γ ≤ β) :
+    fDiv (statInfoFun β γ) μ ν = (2 : ℝ)⁻¹ * (∫ x, |β * ((∂μ/∂ν) x).toReal - γ| ∂ν
+      - β * (μ.singularPart ν) univ + γ * ν univ - β * μ univ) := by
+  have h_eq :
+      (β : EReal) * ((μ.singularPart ν) univ)
+        = ↑(2⁻¹ * (2 * β * ((μ.singularPart ν) univ).toReal)) := by
+    simp [mul_assoc, EReal.coe_ennreal_toReal (measure_ne_top _ _)]
+  rw [fDiv_statInfoFun_eq_integral_max_of_nonpos_of_le hβ hγ, integral_max_eq_integral_abs, h_eq,
+    sub_eq_add_neg, ← EReal.coe_neg, ← EReal.coe_add, ← mul_neg, ← mul_add, EReal.coe_mul]
+  simp_rw [← EReal.coe_ennreal_toReal (measure_ne_top _ _), ← EReal.coe_mul, sub_eq_add_neg,
+    ← EReal.coe_neg, ← EReal.coe_add, add_assoc]
+  congr 3
+  ring
+
+lemma fDiv_statInfoFun_eq_integral_abs_of_nonpos_of_gt [IsFiniteMeasure μ] [IsFiniteMeasure ν]
+    (hβ : β ≤ 0) (hγ : β < γ) :
+    fDiv (statInfoFun β γ) μ ν = (2 : ℝ)⁻¹ * (∫ x, |β * ((∂μ/∂ν) x).toReal - γ| ∂ν
+      - β * (μ.singularPart ν) univ + β * μ univ - γ * ν univ) := by
+  rw [fDiv_statInfoFun_eq_integral_max_of_nonpos_of_gt hβ hγ, integral_max_eq_integral_abs']
+  simp_rw [← EReal.coe_ennreal_toReal (measure_ne_top _ _), ← EReal.coe_mul, sub_eq_add_neg,
+    ← EReal.coe_neg, ← EReal.coe_add, ← EReal.coe_mul]
+  ring_nf
 
 end fDiv
 
@@ -355,17 +479,17 @@ section CurvatureMeasure
 /-- The curvature measure induced by a convex function. It is defined as the only measure that has
 the right derivative of the function as a CDF. -/
 noncomputable
-def curvatureMeasure (f : ℝ → ℝ) (hf : ConvexOn ℝ univ f) : Measure ℝ :=
+def curvatureMeasure {f : ℝ → ℝ} (hf : ConvexOn ℝ univ f) : Measure ℝ :=
   hf.rightDerivStieltjes.measure
 
-instance (f : ℝ → ℝ) (hf : ConvexOn ℝ univ f) : IsLocallyFiniteMeasure (curvatureMeasure f hf) := by
+instance {f : ℝ → ℝ} (hf : ConvexOn ℝ univ f) : IsLocallyFiniteMeasure (curvatureMeasure hf) := by
   unfold curvatureMeasure
   infer_instance
 
 /-- A Taylor formula for convex functions in terms of the right derivative
 and the curvature measure. -/
 theorem convex_taylor (hf : ConvexOn ℝ univ f) (hf_cont : Continuous f) {a b : ℝ} :
-    f b - f a - (rightDeriv f a) * (b - a)  = ∫ x in a..b, b - x ∂(curvatureMeasure f hf) := by
+    f b - f a - (rightDeriv f a) * (b - a)  = ∫ x in a..b, b - x ∂(curvatureMeasure hf) := by
   have h_int : IntervalIntegrable (rightDeriv f) ℙ a b := hf.rightDeriv_mono.intervalIntegrable
   rw [← intervalIntegral.integral_eq_sub_of_hasDeriv_right hf_cont.continuousOn
     (fun x _ ↦ hf.hadDerivWithinAt_rightDeriv x) h_int]
@@ -380,9 +504,9 @@ theorem convex_taylor (hf : ConvexOn ℝ univ f) (hf_cont : Continuous f) {a b :
 
 lemma fun_eq_integral_statInfoFun_curvatureMeasure (hf_cvx : ConvexOn ℝ univ f)
     (hf_cont : Continuous f) (hf_one : f 1 = 0) (hfderiv_one : rightDeriv f 1 = 0) :
-    f t = ∫ y, statInfoFun 1 y t ∂(curvatureMeasure f hf_cvx) := by
+    f t = ∫ y, statInfoFun 1 y t ∂(curvatureMeasure hf_cvx) := by
   have h :
-      f t - f 1 - (rightDeriv f 1) * (t - 1) = ∫ x in (1)..t, t - x ∂(curvatureMeasure f hf_cvx) :=
+      f t - f 1 - (rightDeriv f 1) * (t - 1) = ∫ x in (1)..t, t - x ∂(curvatureMeasure hf_cvx) :=
     convex_taylor hf_cvx hf_cont
   rw [hf_one, hfderiv_one, sub_zero, zero_mul, sub_zero] at h
   rw [h]
@@ -399,7 +523,7 @@ lemma fDiv_eq_integral_fDiv_statInfoFun_of_absolutelyContinuous
     (hf_cvx : ConvexOn ℝ univ f) (hf_cont : Continuous f) (hf_one : f 1 = 0)
     (hfderiv_one : rightDeriv f 1 = 0) (h_int : Integrable (fun x ↦ f ((∂μ/∂ν) x).toReal) ν)
     (h_ac : μ ≪ ν) :
-    fDiv f μ ν = ∫ x, (fDiv (statInfoFun 1 x) μ ν).toReal ∂(curvatureMeasure f hf_cvx) := by
+    fDiv f μ ν = ∫ x, (fDiv (statInfoFun 1 x) μ ν).toReal ∂(curvatureMeasure hf_cvx) := by
   classical
   rw [fDiv_of_absolutelyContinuous h_ac, if_pos h_int, EReal.coe_eq_coe_iff]
   simp_rw [fDiv_of_absolutelyContinuous h_ac, if_pos (integrable_statInfoFun_rnDeriv 1 _ _ _),
@@ -411,9 +535,9 @@ lemma fDiv_eq_integral_fDiv_statInfoFun_of_absolutelyContinuous
     refine stronglymeasurable_statInfoFun.measurable.comp ?_
     refine (measurable_const.prod_mk measurable_snd).prod_mk ?_
     exact ((Measure.measurable_rnDeriv μ ν).comp measurable_fst).ennreal_toReal
-  have int_eq_lint : ∫ x, ∫ γ, statInfoFun 1 γ ((∂μ/∂ν) x).toReal ∂curvatureMeasure f hf_cvx ∂ν
+  have int_eq_lint : ∫ x, ∫ γ, statInfoFun 1 γ ((∂μ/∂ν) x).toReal ∂curvatureMeasure hf_cvx ∂ν
       = (∫⁻ x, ∫⁻ γ, ENNReal.ofReal (statInfoFun 1 γ ((∂μ/∂ν) x).toReal)
-        ∂curvatureMeasure f hf_cvx ∂ν).toReal := by
+        ∂curvatureMeasure hf_cvx ∂ν).toReal := by
     rw [integral_eq_lintegral_of_nonneg_ae]
     rotate_left
     · exact eventually_of_forall fun _ ↦ (integral_nonneg (fun _ ↦ statInfoFun_nonneg _ _ _))

--- a/TestingLowerBounds/StatInfoFun.lean
+++ b/TestingLowerBounds/StatInfoFun.lean
@@ -374,9 +374,9 @@ lemma fDiv_statInfoFun_eq_integral_max_of_nonpos_of_gt [IsFiniteMeasure μ] [IsF
 /-- Auxiliary lemma for `fDiv_statInfoFun_eq_integral_abs_of_nonneg_of_le` and
 `fDiv_statInfoFun_eq_integral_abs_of_nonpos_of_le`. -/
 lemma integral_max_eq_integral_abs [IsFiniteMeasure μ] [IsFiniteMeasure ν] :
-    ∫ x, max 0 (γ - β * ((∂μ/∂ν) x).toReal) ∂ν = (2 : ℝ)⁻¹ * (∫ x, |β * ((∂μ/∂ν) x).toReal
-      - γ| ∂ν + γ * (ν univ).toReal - β * (μ univ).toReal
-      + β * ((μ.singularPart ν) univ).toReal) := by
+    ∫ x, max 0 (γ - β * ((∂μ/∂ν) x).toReal) ∂ν
+      = 2⁻¹ * (∫ x, |β * ((∂μ/∂ν) x).toReal - γ| ∂ν + γ * (ν univ).toReal - β * (μ univ).toReal
+        + β * ((μ.singularPart ν) univ).toReal) := by
   simp_rw [max_eq_add_add_abs_sub, zero_add, zero_sub, neg_sub, integral_mul_left]
   congr
   have h_int : Integrable (fun x ↦ β * ((∂μ/∂ν) x).toReal) ν :=
@@ -392,16 +392,16 @@ lemma integral_max_eq_integral_abs [IsFiniteMeasure μ] [IsFiniteMeasure ν] :
     Measure.restrict_univ]
   rw [ENNReal.toReal_add (measure_ne_top _ _)]
   swap; · exact lt_top_iff_ne_top.mp <| (setLIntegral_univ _ ▸
-      Measure.setLIntegral_rnDeriv_le univ).trans_lt IsFiniteMeasure.measure_univ_lt_top
+    Measure.setLIntegral_rnDeriv_le univ).trans_lt IsFiniteMeasure.measure_univ_lt_top
   ring_nf
   rw [integral_toReal (Measure.measurable_rnDeriv μ ν).aemeasurable (Measure.rnDeriv_lt_top μ ν)]
 
 /-- Auxiliary lemma for `fDiv_statInfoFun_eq_integral_abs_of_nonneg_of_gt` and
 `fDiv_statInfoFun_eq_integral_abs_of_nonpos_of_gt`. -/
 lemma integral_max_eq_integral_abs' [IsFiniteMeasure μ] [IsFiniteMeasure ν] :
-    ∫ x, max 0 (β * ((∂μ/∂ν) x).toReal - γ) ∂ν = (2 : ℝ)⁻¹ * (∫ x, |β * ((∂μ/∂ν) x).toReal
-      - γ| ∂ν - γ * (ν univ).toReal + β * (μ univ).toReal
-      - β * ((μ.singularPart ν) univ).toReal) := by
+    ∫ x, max 0 (β * ((∂μ/∂ν) x).toReal - γ) ∂ν
+      = 2⁻¹ * (∫ x, |β * ((∂μ/∂ν) x).toReal - γ| ∂ν - γ * (ν univ).toReal + β * (μ univ).toReal
+        - β * ((μ.singularPart ν) univ).toReal) := by
   simp_rw [max_eq_add_add_abs_sub, zero_add, zero_sub, abs_neg, integral_mul_left]
   congr
   have h_int : Integrable (fun x ↦ β * ((∂μ/∂ν) x).toReal) ν :=
@@ -417,7 +417,7 @@ lemma integral_max_eq_integral_abs' [IsFiniteMeasure μ] [IsFiniteMeasure ν] :
     Measure.restrict_univ]
   rw [ENNReal.toReal_add (measure_ne_top _ _)]
   swap; · exact lt_top_iff_ne_top.mp <| (setLIntegral_univ _ ▸
-      Measure.setLIntegral_rnDeriv_le univ).trans_lt IsFiniteMeasure.measure_univ_lt_top
+    Measure.setLIntegral_rnDeriv_le univ).trans_lt IsFiniteMeasure.measure_univ_lt_top
   ring_nf
   rw [integral_toReal (Measure.measurable_rnDeriv μ ν).aemeasurable (Measure.rnDeriv_lt_top μ ν)]
 


### PR DESCRIPTION
- Add the integral form of the `fDiv` of `StatInfoFun`, the one with the max: `fDiv_statInfoFun_eq_integral_max_of_nonneg_of_le` and similar lemmas.
- Add the auxiliary lemmas `integral_max_eq_integral_abs` and `integral_max_eq_integral_abs'`.
- Add the integral form of the `fDiv` of `StatInfoFun`, the one with the absolute value:  `fDiv_statInfoFun_eq_integral_abs_of_nonneg_of_le` and similar lemmas.
- Refactor `measurable_statInfoFun3` to `stronglyMeasurable_statInfoFun3` and fix dependncies.
- Golf proof of `derivAtTop_statInfoFun_ne_top`.
- Cleanup.


-Depends on #98