### PR TITLE
Lint

### DIFF
--- a/TestingLowerBounds/ForMathlib/Integrable_of_empty.lean
+++ b/TestingLowerBounds/ForMathlib/Integrable_of_empty.lean
@@ -7,7 +7,6 @@ open Filter
 
 namespace MeasureTheory
 
-@[simp]
 lemma Integrable.of_isEmpty {α β : Type*} [MeasurableSpace α] [NormedAddCommGroup β]
     [IsEmpty α] (f : α → β) (μ : Measure α) : Integrable f μ := Integrable.of_finite μ f
 

--- a/TestingLowerBounds/Kernel/Basic.lean
+++ b/TestingLowerBounds/Kernel/Basic.lean
@@ -26,19 +26,18 @@ lemma snd_compProd_prodMkLeft
   · rfl
   · exact measurable_snd hs
 
-lemma map_comp (κ : kernel α β) [IsSFiniteKernel κ] (η : kernel β γ) [IsSFiniteKernel η]
-    {f : γ → δ} (hf : Measurable f) :
+lemma map_comp (κ : kernel α β) (η : kernel β γ) {f : γ → δ} (hf : Measurable f) :
     kernel.map (η ∘ₖ κ) f hf = (kernel.map η f hf) ∘ₖ κ := by
   ext a s hs
   rw [map_apply' _ hf _ hs, comp_apply', comp_apply' _ _ _ hs]
   · simp_rw [map_apply' _ hf _ hs]
   · exact hf hs
 
-lemma fst_comp (κ : kernel α β) [IsSFiniteKernel κ] (η : kernel β (γ × δ)) [IsSFiniteKernel η] :
+lemma fst_comp (κ : kernel α β) (η : kernel β (γ × δ)) :
     fst (η ∘ₖ κ) = fst η ∘ₖ κ :=
   kernel.map_comp κ η measurable_fst
 
-lemma snd_comp (κ : kernel α β) [IsSFiniteKernel κ] (η : kernel β (γ × δ)) [IsSFiniteKernel η] :
+lemma snd_comp (κ : kernel α β) (η : kernel β (γ × δ)) :
     snd (η ∘ₖ κ) = snd η ∘ₖ κ :=
   kernel.map_comp κ η measurable_snd
 

--- a/TestingLowerBounds/Kernel/Monoidal.lean
+++ b/TestingLowerBounds/Kernel/Monoidal.lean
@@ -138,7 +138,7 @@ lemma parallelComp_apply (κ : kernel α β) [IsSFiniteKernel κ]
     (κ ∥ₖ η) x = (κ x.1).prod (η x.2) := by
   rw [parallelComp, prod_apply, prodMkRight_apply, prodMkLeft_apply]
 
-instance (κ : kernel α β) [IsSFiniteKernel κ] (η : kernel γ δ) [IsSFiniteKernel η] :
+instance (κ : kernel α β) (η : kernel γ δ) :
     IsSFiniteKernel (κ ∥ₖ η) := by
   rw [parallelComp]; infer_instance
 

--- a/TestingLowerBounds/MeasureCompProd.lean
+++ b/TestingLowerBounds/MeasureCompProd.lean
@@ -147,6 +147,11 @@ instance {μ : Measure α} [IsProbabilityMeasure μ] {κ : kernel α β} [IsMark
   rw [Measure.comp_eq_snd_compProd]
   infer_instance
 
+lemma Measure.fst_swap_compProd [SFinite μ] [IsSFiniteKernel κ] :
+    ((μ ⊗ₘ κ).map Prod.swap).fst = μ ∘ₘ κ := by
+  simp only [Measure.fst_map_swap]
+  rw [Measure.comp_eq_snd_compProd]
+
 section ParallelComp
 
 namespace kernel

--- a/TestingLowerBounds/MeasureCompProd.lean
+++ b/TestingLowerBounds/MeasureCompProd.lean
@@ -149,8 +149,7 @@ instance {μ : Measure α} [IsProbabilityMeasure μ] {κ : kernel α β} [IsMark
 
 lemma Measure.fst_swap_compProd [SFinite μ] [IsSFiniteKernel κ] :
     ((μ ⊗ₘ κ).map Prod.swap).fst = μ ∘ₘ κ := by
-  simp only [Measure.fst_map_swap]
-  rw [Measure.comp_eq_snd_compProd]
+  simp [Measure.comp_eq_snd_compProd]
 
 section ParallelComp
 

--- a/TestingLowerBounds/MeasureCompProd.lean
+++ b/TestingLowerBounds/MeasureCompProd.lean
@@ -40,8 +40,7 @@ variable {α β γ : Type*} {mα : MeasurableSpace α} {mβ : MeasurableSpace β
 Defined using `MeasureTheory.Measure.bind` -/
 scoped[ProbabilityTheory] infixl:100 " ∘ₘ " => MeasureTheory.Measure.bind
 
-lemma Measure.comp_assoc {μ : Measure α} [SFinite μ]
-    {κ : kernel α β} [IsSFiniteKernel κ] {η : kernel β γ} [IsSFiniteKernel η] :
+lemma Measure.comp_assoc {μ : Measure α} {κ : kernel α β} {η : kernel β γ} :
     μ ∘ₘ κ ∘ₘ η = μ ∘ₘ (η ∘ₖ κ) :=
   Measure.bind_bind (kernel.measurable _) (kernel.measurable _)
 
@@ -148,22 +147,6 @@ instance {μ : Measure α} [IsProbabilityMeasure μ] {κ : kernel α β} [IsMark
   rw [Measure.comp_eq_snd_compProd]
   infer_instance
 
-@[simp]
-lemma Measure.fst_map_swap {μ : Measure (α × β)} : (μ.map Prod.swap).fst = μ.snd := by
-  rw [Measure.fst, Measure.map_map measurable_fst measurable_swap]
-  congr
-
-@[simp]
-lemma Measure.snd_map_swap {μ : Measure (α × β)} : (μ.map Prod.swap).snd = μ.fst := by
-  rw [Measure.snd, Measure.map_map measurable_snd measurable_swap]
-  congr
-
-@[simp]
-lemma Measure.fst_swap_compProd [SFinite μ] [IsSFiniteKernel κ] :
-    ((μ ⊗ₘ κ).map Prod.swap).fst = μ ∘ₘ κ := by
-  rw [Measure.comp_eq_snd_compProd]
-  simp
-
 section ParallelComp
 
 namespace kernel
@@ -171,7 +154,7 @@ namespace kernel
 variable {δ : Type*} {mδ : MeasurableSpace δ}
 
 lemma _root_.MeasureTheory.Measure.prod_comp_right
-    (μ : Measure α) [SFinite μ] (ν : Measure β) [SFinite ν]
+    (μ : Measure α) (ν : Measure β) [SFinite ν]
     (κ : kernel β γ) [IsSFiniteKernel κ] :
     μ.prod (ν ∘ₘ κ) = (μ.prod ν) ∘ₘ (kernel.id ∥ₖ κ) := by
   ext s hs
@@ -314,7 +297,7 @@ theorem _root_.MeasureTheory.Integrable.integral_norm_compProd' [NormedAddCommGr
   hf.integral_norm_compProd
 
 theorem _root_.MeasureTheory.Integrable.integral_compProd' [NormedAddCommGroup E]
-    [SFinite μ] [IsSFiniteKernel κ] ⦃f : α × β → E⦄ [NormedSpace ℝ E] [CompleteSpace E]
+    [SFinite μ] [IsSFiniteKernel κ] ⦃f : α × β → E⦄ [NormedSpace ℝ E]
     (hf : Integrable f (μ ⊗ₘ κ)) :
     Integrable (fun x ↦ ∫ y, f (x, y) ∂(κ x)) μ :=
   hf.integral_compProd


### PR DESCRIPTION
- remove unused arguments
- remove two lemmas now in mathlib
- remove `@[simp]` from a lemma that can be proved by simp.