### PR TITLE
Add integral representation for `StatInfo`

### DIFF
--- a/TestingLowerBounds/Divergences/StatInfo.lean
+++ b/TestingLowerBounds/Divergences/StatInfo.lean
@@ -9,6 +9,7 @@ import Mathlib.Order.CompletePartialOrder
 import TestingLowerBounds.FDiv.Basic
 import TestingLowerBounds.Testing.Binary
 import Mathlib.MeasureTheory.Constructions.Prod.Integral
+import TestingLowerBounds.ForMathlib.SetIntegral
 
 /-!
 # Statistical information
@@ -145,6 +146,252 @@ lemma toReal_statInfo_eq_min_sub_integral (μ ν : Measure 𝒳) [IsFiniteMeasur
   swap; · simp only [ne_eq, min_eq_top, hμ, hν, and_self, not_false_eq_true]
   rw [toReal_bayesBinaryRisk_eq_integral_min,
     MonotoneOn.map_min (fun _ _ _ hb hab ↦ ENNReal.toReal_mono hb hab) hμ hν]
+
+lemma toReal_statInfo_eq_min_sub_integral' {μ ν ζ : Measure 𝒳} [IsFiniteMeasure μ] [IsFiniteMeasure ν]
+    [SigmaFinite ζ] (π : Measure Bool) [IsFiniteMeasure π]  (hμζ : μ ≪ ζ) (hνζ : ν ≪ ζ) :
+    (statInfo μ ν π).toReal = min (π {false} * μ univ).toReal (π {true} * ν univ).toReal
+      - ∫ x, min (π {false} * (∂μ/∂ζ) x).toReal (π {true} * (∂ν/∂ζ) x).toReal ∂ζ := by
+  have hμ : π {false} * μ univ ≠ ⊤ := ENNReal.mul_ne_top (measure_ne_top π _) (measure_ne_top μ _)
+  have hν : π {true} * ν univ ≠ ⊤ := ENNReal.mul_ne_top (measure_ne_top π _) (measure_ne_top ν _)
+  rw [statInfo_eq_min_sub_lintegral' π hμζ hνζ, ENNReal.toReal_sub_of_le]
+  rotate_left
+  · sorry
+  · simp only [ne_eq, min_eq_top, hμ, hν, and_self, not_false_eq_true]
+  rw [MonotoneOn.map_min (fun _ _ _ hb hab ↦ ENNReal.toReal_mono hb hab) hμ hν]
+  sorry
+
+lemma statInfo_eq_abs_add_lintegral_abs (μ ν : Measure 𝒳) [IsFiniteMeasure μ] [IsFiniteMeasure ν]
+    (π : Measure Bool) [IsFiniteMeasure π] :
+    statInfo μ ν π = 2⁻¹ * (∫⁻ x, ‖(π {false} * (∂μ/∂twoHypKernel μ ν ∘ₘ π) x).toReal
+      - (π {true} * (∂ν/∂twoHypKernel μ ν ∘ₘ π) x).toReal‖₊ ∂(twoHypKernel μ ν ∘ₘ π)
+      - (↑|(π {false} * μ univ).toReal - (π {true} * ν univ).toReal| : EReal)) := by
+  have hμ : π {false} * μ univ ≠ ⊤ := ENNReal.mul_ne_top (measure_ne_top π _) (measure_ne_top μ _)
+  have hν : π {true} * ν univ ≠ ⊤ := ENNReal.mul_ne_top (measure_ne_top π _) (measure_ne_top ν _)
+  rw [statInfo_eq_min_sub, bayesBinaryRisk_eq_lintegral_ennnorm]
+  rw [← ENNReal.ofReal_toReal (a := min _ _)]
+  swap
+  · simp only [ne_eq, min_eq_top, hμ, hν, and_self, not_false_eq_true]
+  rw [MonotoneOn.map_min (fun _ _ _ hb hab ↦ ENNReal.toReal_mono hb hab) hμ hν]
+  rw [min_eq_add_sub_abs_sub]
+  rw [ENNReal.ofReal_mul (by positivity), ENNReal.ofReal_sub _ (abs_nonneg _)]
+  rw [ENNReal.ofReal_inv_of_pos zero_lt_two, ENNReal.ofReal_ofNat]
+  rw [ENNReal.ofReal_add ENNReal.toReal_nonneg ENNReal.toReal_nonneg]
+  rw [ENNReal.ofReal_toReal hμ, ENNReal.ofReal_toReal hν]
+  simp_rw [ENNReal.mul_sub (fun _ _ ↦ ENNReal.inv_ne_top.mpr (NeZero.ne 2))]
+  nth_rw 1 [measure_comp_twoHypKernel]
+  simp_rw [Measure.coe_add, Pi.add_apply, Measure.coe_smul, Pi.smul_apply, smul_eq_mul, add_comm]
+  --this is hard to prove, because we have to deal with a lot of ENNReals and subtractions and they do not work well together, for now I am leaving this. Maybe it could be a good idea to do the toReal version first, proving it starting from the previous lemma (making a toReal version of that as well) essentially mimiking the results for the binary, but here we would have to do double the work, because we have both the version with twoHypKernel μ ν ∘ₘ π and the one with ζ
+  sorry
+
+lemma toReal_statInfo_eq_integral_max_of_le {μ ν : Measure 𝒳} [IsFiniteMeasure μ] [IsFiniteMeasure ν]
+    {π : Measure Bool} [IsFiniteMeasure π] (h : π {false} * μ univ ≤ π {true} * ν univ) :
+    (statInfo μ ν π).toReal
+      = ∫ x, max 0 ((π {false} * (∂μ/∂ν) x).toReal - (π {true}).toReal) ∂ν
+        + (π {false} * μ.singularPart ν univ).toReal := by
+  by_cases h_false : π {false} = 0
+  · simp [statInfo, h_false, bayesBinaryRisk_of_measure_false_eq_zero]
+  by_cases h_true : π {true} = 0
+  · simp [statInfo, h_true, bayesBinaryRisk_of_measure_true_eq_zero] at h ⊢
+    rcases h with (h | h)
+    · simp [h]
+    · rw [integral_congr_ae (g := 0)]
+      swap
+      · filter_upwards [Measure.rnDeriv_zero ν] with x hx
+        simp [h, hx]
+      simp [h]
+  have hμac : μ ≪ (twoHypKernel μ ν ∘ₘ π) :=
+    absolutelyContinuous_measure_comp_twoHypKernel_left μ ν h_false
+  have hνac : ν ≪ (twoHypKernel μ ν ∘ₘ π) :=
+    absolutelyContinuous_measure_comp_twoHypKernel_right μ ν h_true
+  rw [toReal_statInfo_eq_min_sub_integral, min_eq_left ((ENNReal.toReal_le_toReal _ _).mpr h)]
+    <;> try simp only [ne_eq, measure_ne_top _ _, not_false_eq_true, ENNReal.mul_ne_top]
+  let s := Measure.singularPartSet μ ν
+  have hs : MeasurableSet s := Measure.measurableSet_singularPartSet
+  calc
+    _ = (π {false} * μ univ).toReal
+        - ∫ x, (π {false} * (∂μ/∂twoHypKernel μ ν ∘ₘ π) x).toReal
+          + min 0 ((π {true} * (∂ν/∂twoHypKernel μ ν ∘ₘ π) x).toReal
+            - (π {false} * (∂μ/∂twoHypKernel μ ν ∘ₘ π) x).toReal) ∂twoHypKernel μ ν ∘ₘ π := by
+      congr with x
+      nth_rw 1 [← add_zero (π _ * _).toReal, ← add_sub_cancel_left
+        (π {false} * (∂μ/∂twoHypKernel μ ν ∘ₘ π) x).toReal (π {true} * _).toReal]
+      rw [add_sub_assoc, min_add_add_left]
+    _ = (π {false} * μ univ).toReal
+        - (∫ x, (π {false} * (∂μ/∂twoHypKernel μ ν ∘ₘ π) x).toReal ∂twoHypKernel μ ν ∘ₘ π
+        + ∫ x, min 0 ((π {true} * (∂ν/∂twoHypKernel μ ν ∘ₘ π) x).toReal
+            - (π {false} * (∂μ/∂twoHypKernel μ ν ∘ₘ π) x).toReal) ∂twoHypKernel μ ν ∘ₘ π) := by
+      simp_rw [ENNReal.toReal_mul, ← inf_eq_min]
+      congr
+      refine integral_add (Integrable.const_mul Measure.integrable_toReal_rnDeriv _) ?_
+      refine (integrable_zero _ _ _).inf (Integrable.sub ?_ ?_) <;>
+      · exact Measure.integrable_toReal_rnDeriv.const_mul _
+    _ = - ∫ x, min 0 ((π {true} * (∂ν/∂twoHypKernel μ ν ∘ₘ π) x).toReal
+          - (π {false} * (∂μ/∂twoHypKernel μ ν ∘ₘ π) x).toReal) ∂twoHypKernel μ ν ∘ₘ π := by
+      simp_rw [ENNReal.toReal_mul, ← sub_sub, sub_eq_neg_self, sub_eq_zero, integral_mul_left,
+        Measure.integral_toReal_rnDeriv hμac]
+    _ = ∫ x, max 0 ((π {false} * (∂μ/∂twoHypKernel μ ν ∘ₘ π) x).toReal
+        - (π {true} * (∂ν/∂twoHypKernel μ ν ∘ₘ π) x).toReal) ∂twoHypKernel μ ν ∘ₘ π := by
+      simp [← integral_neg, ← inf_eq_min, ← sup_eq_max, neg_inf]
+    _ = ∫ x in s, max 0 ((π {false} * (∂μ/∂twoHypKernel μ ν ∘ₘ π) x).toReal
+          - (π {true} * (∂ν/∂twoHypKernel μ ν ∘ₘ π) x).toReal) ∂twoHypKernel μ ν ∘ₘ π
+        + ∫ x in sᶜ, max 0 ((π {false} * (∂μ/∂twoHypKernel μ ν ∘ₘ π) x).toReal
+          - (π {true} * (∂ν/∂twoHypKernel μ ν ∘ₘ π) x).toReal) ∂twoHypKernel μ ν ∘ₘ π := by
+      simp_rw [ENNReal.toReal_mul]
+      refine integral_add_compl hs ((integrable_zero _ _ _).sup (Integrable.sub ?_ ?_)) |>.symm <;>
+      · exact Measure.integrable_toReal_rnDeriv.const_mul _
+    _ = ∫ x in s, max 0 (π {false} * (∂(μ.singularPart ν)/∂twoHypKernel μ ν ∘ₘ π) x).toReal
+          ∂twoHypKernel μ ν ∘ₘ π
+        + ∫ x in sᶜ, (max 0
+            ((π {false} * (∂μ.restrict (μ.singularPartSet ν)ᶜ/∂ν) x).toReal - (π {true}).toReal))
+          * ((∂ν/∂twoHypKernel μ ν ∘ₘ π) x).toReal ∂twoHypKernel μ ν ∘ₘ π := by
+      congr 1
+      · apply setIntegral_congr_ae hs
+        filter_upwards [Measure.rnDeriv_eq_zero_ae_of_singularPartSet  μ ν _, Measure.rnDeriv_add'
+          (μ.singularPart ν) (ν.withDensity (μ.rnDeriv ν)) (twoHypKernel μ ν ∘ₘ π),
+          Measure.rnDeriv_withDensity_left_of_absolutelyContinuous hνac
+          (Measure.measurable_rnDeriv μ ν).aemeasurable] with x hx1 hx2 hx3
+        intro hxs
+        nth_rw 1 [← Measure.singularPart_add_rnDeriv μ ν]
+        simp_rw [hx2, Pi.add_apply, hx3, hx1 hxs, mul_zero, ENNReal.zero_toReal, sub_zero, add_zero]
+      · apply setIntegral_congr_ae hs.compl
+        filter_upwards [Measure.rnDeriv_restrict μ (twoHypKernel μ ν ∘ₘ π) hs.compl,
+          Measure.rnDeriv_mul_rnDeriv
+          (Measure.absolutelyContinuous_restrict_compl_singularPartSet μ ν)] with x hx1 hx2 hxs
+        rw [max_mul_of_nonneg _ _ ENNReal.toReal_nonneg, zero_mul, sub_mul]
+        rw [Set.indicator_of_mem hxs] at hx1
+        simp_rw [ENNReal.toReal_mul, mul_assoc, ← hx1, ← hx2, Pi.mul_apply, ENNReal.toReal_mul]
+    _ = ∫ x, max 0 (π {false} * (∂(μ.singularPart ν)/∂twoHypKernel μ ν ∘ₘ π) x).toReal
+          ∂twoHypKernel μ ν ∘ₘ π
+        + ∫ x in sᶜ, (max 0 ((π {false}
+          * (∂μ.restrict (μ.singularPartSet ν)ᶜ/∂ν) x).toReal - (π {true}).toReal)) ∂ν := by
+      congr 1
+      · nth_rw 2 [← integral_add_compl hs]
+        swap
+        · simp_rw [ENNReal.toReal_mul]
+          exact ((integrable_zero _ _ _).sup (Measure.integrable_toReal_rnDeriv.const_mul _))
+        refine self_eq_add_right.mpr <| setIntegral_eq_zero_of_ae_eq_zero ?_
+        filter_upwards [Measure.rnDeriv_restrict μ _ hs] with x hx
+        intro hxs
+        rw [← Measure.restrict_singularPartSet_eq_singularPart, hx, indicator_of_not_mem hxs,
+          mul_zero, ENNReal.zero_toReal, max_self]
+      · simp_rw [mul_comm _ ((∂ν/∂_ ∘ₘ _) _).toReal, ← smul_eq_mul]
+        rw [setIntegral_rnDeriv_smul hνac hs.compl]
+    _ = ∫ x, (π {false} * (∂(μ.singularPart ν)/∂twoHypKernel μ ν ∘ₘ π) x).toReal
+          ∂twoHypKernel μ ν ∘ₘ π
+        + ∫ x in sᶜ, (max 0 ((π {false} * (∂μ/∂ν) x).toReal - (π {true}).toReal)) ∂ν := by
+      simp_rw [max_eq_right ENNReal.toReal_nonneg]
+      congr 1
+      apply setIntegral_congr_ae hs.compl
+      filter_upwards [Measure.rnDeriv_restrict μ ν hs.compl] with x hx1 hxs
+      rw [hx1, indicator_of_mem hxs]
+    _ = ∫ x, (max 0 ((π {false} * (∂μ/∂ν) x).toReal - (π {true}).toReal)) ∂ν
+        + (π {false} * (μ.singularPart ν) univ).toReal := by
+      simp_rw [ENNReal.toReal_mul, add_comm (∫ _, _ ∂_ ∘ₘ _)]
+      rw [integral_mul_left, Measure.integral_toReal_rnDeriv
+        ((Measure.singularPart_le μ ν).absolutelyContinuous.trans hμac)]
+      nth_rw 2 [← integral_add_compl hs]
+      swap
+      · exact (integrable_zero _ _ _).sup
+          ((Measure.integrable_toReal_rnDeriv.const_mul _).sub (integrable_const _))
+      rw [setIntegral_zero_measure _ (Measure.measure_singularPartSet μ ν), zero_add]
+
+
+lemma toReal_statInfo_eq_integral_max_of_gt {μ ν : Measure 𝒳} [IsFiniteMeasure μ] [IsFiniteMeasure ν]
+    {π : Measure Bool} [IsFiniteMeasure π] (h : π {true} * ν univ < π {false} * μ univ) :
+    (statInfo μ ν π).toReal
+      = ∫ x, max 0 ((π {true}).toReal - (π {false} * (∂μ/∂ν) x).toReal) ∂ν := by
+  by_cases h_false : π {false} = 0
+  · simp [h_false] at h
+  by_cases h_true : π {true} = 0
+  · have (x : 𝒳) : 0 ≥ -((π {false}).toReal * ((∂μ/∂ν) x).toReal) := neg_nonpos.mpr (by positivity)
+    simp [statInfo, h_true, bayesBinaryRisk_of_measure_true_eq_zero, max_eq_left (this _)]
+  have hνac : ν ≪ (twoHypKernel μ ν ∘ₘ π) :=
+    absolutelyContinuous_measure_comp_twoHypKernel_right μ ν h_true
+  rw [toReal_statInfo_eq_min_sub_integral, min_eq_right ((ENNReal.toReal_le_toReal _ _).mpr h.le)]
+    <;> try simp only [ne_eq, measure_ne_top _ _, not_false_eq_true, ENNReal.mul_ne_top]
+  let s := Measure.singularPartSet μ ν
+  have hs : MeasurableSet s := Measure.measurableSet_singularPartSet
+  calc
+    _ = (π {true} * ν univ).toReal
+        - ∫ x, (π {true} * (∂ν/∂twoHypKernel μ ν ∘ₘ π) x).toReal
+          + min 0 ((π {false} * (∂μ/∂twoHypKernel μ ν ∘ₘ π) x).toReal
+            - (π {true} * (∂ν/∂twoHypKernel μ ν ∘ₘ π) x).toReal) ∂twoHypKernel μ ν ∘ₘ π := by
+      congr with x
+      nth_rw 1 [min_comm, ← add_zero (π _ * _).toReal, ← add_sub_cancel_left
+        (π {true} * (∂ν/∂twoHypKernel μ ν ∘ₘ π) x).toReal (π {false} * _).toReal]
+      rw [add_sub_assoc, min_add_add_left]
+    _ = (π {true} * ν univ).toReal
+        - (∫ x, (π {true} * (∂ν/∂twoHypKernel μ ν ∘ₘ π) x).toReal ∂twoHypKernel μ ν ∘ₘ π
+        + ∫ x, min 0 ((π {false} * (∂μ/∂twoHypKernel μ ν ∘ₘ π) x).toReal
+            - (π {true} * (∂ν/∂twoHypKernel μ ν ∘ₘ π) x).toReal) ∂twoHypKernel μ ν ∘ₘ π) := by
+      simp_rw [ENNReal.toReal_mul, ← inf_eq_min]
+      congr
+      refine integral_add (Integrable.const_mul Measure.integrable_toReal_rnDeriv _) ?_
+      refine (integrable_zero _ _ _).inf (Integrable.sub ?_ ?_) <;>
+      · exact Measure.integrable_toReal_rnDeriv.const_mul _
+    _ = - ∫ x, min 0 ((π {false} * (∂μ/∂twoHypKernel μ ν ∘ₘ π) x).toReal
+          - (π {true} * (∂ν/∂twoHypKernel μ ν ∘ₘ π) x).toReal) ∂twoHypKernel μ ν ∘ₘ π := by
+      simp_rw [ENNReal.toReal_mul, ← sub_sub, sub_eq_neg_self, sub_eq_zero, integral_mul_left,
+        Measure.integral_toReal_rnDeriv hνac]
+    _ = ∫ x, max 0 ((π {true} * (∂ν/∂twoHypKernel μ ν ∘ₘ π) x).toReal
+        - (π {false} * (∂μ/∂twoHypKernel μ ν ∘ₘ π) x).toReal) ∂twoHypKernel μ ν ∘ₘ π := by
+      simp [← integral_neg, ← inf_eq_min, ← sup_eq_max, neg_inf]
+    _ = ∫ x in s, max 0 ((π {true} * (∂ν/∂twoHypKernel μ ν ∘ₘ π) x).toReal
+          - (π {false} * (∂μ/∂twoHypKernel μ ν ∘ₘ π) x).toReal) ∂twoHypKernel μ ν ∘ₘ π
+        + ∫ x in sᶜ, max 0 ((π {true} * (∂ν/∂twoHypKernel μ ν ∘ₘ π) x).toReal
+          - (π {false} * (∂μ/∂twoHypKernel μ ν ∘ₘ π) x).toReal) ∂twoHypKernel μ ν ∘ₘ π := by
+      simp_rw [ENNReal.toReal_mul]
+      refine integral_add_compl hs ((integrable_zero _ _ _).sup (Integrable.sub ?_ ?_)) |>.symm <;>
+      · exact Measure.integrable_toReal_rnDeriv.const_mul _
+    _ = ∫ x in s, max 0 (-(π {false} * (∂(μ.singularPart ν)/∂twoHypKernel μ ν ∘ₘ π) x).toReal)
+          ∂twoHypKernel μ ν ∘ₘ π
+        + ∫ x in sᶜ, (max 0
+            ((π {true}).toReal - (π {false} * (∂μ.restrict (μ.singularPartSet ν)ᶜ/∂ν) x).toReal))
+          * ((∂ν/∂twoHypKernel μ ν ∘ₘ π) x).toReal ∂twoHypKernel μ ν ∘ₘ π := by
+      congr 1
+      · apply setIntegral_congr_ae hs
+        filter_upwards [Measure.rnDeriv_eq_zero_ae_of_singularPartSet  μ ν _, Measure.rnDeriv_add'
+          (μ.singularPart ν) (ν.withDensity (μ.rnDeriv ν)) (twoHypKernel μ ν ∘ₘ π),
+          Measure.rnDeriv_withDensity_left_of_absolutelyContinuous hνac
+          (Measure.measurable_rnDeriv μ ν).aemeasurable] with x hx1 hx2 hx3 hxs
+        nth_rw 2 [← Measure.singularPart_add_rnDeriv μ ν]
+        simp_rw [hx2, Pi.add_apply, hx3, hx1 hxs, mul_zero, ENNReal.zero_toReal, zero_sub, add_zero]
+      · apply setIntegral_congr_ae hs.compl
+        filter_upwards [Measure.rnDeriv_restrict μ (twoHypKernel μ ν ∘ₘ π) hs.compl,
+          Measure.rnDeriv_mul_rnDeriv
+          (Measure.absolutelyContinuous_restrict_compl_singularPartSet μ ν)] with x hx1 hx2 hxs
+        rw [max_mul_of_nonneg _ _ ENNReal.toReal_nonneg, zero_mul, sub_mul]
+        rw [Set.indicator_of_mem hxs] at hx1
+        simp_rw [ENNReal.toReal_mul, mul_assoc, ← hx1, ← hx2, Pi.mul_apply, ENNReal.toReal_mul]
+    _ = ∫ x in sᶜ, max 0 ((π {true}).toReal
+          - (π {false} * (∂μ.restrict (μ.singularPartSet ν)ᶜ/∂ν) x).toReal) ∂ν := by
+      simp_rw [max_eq_left (neg_nonpos.mpr ENNReal.toReal_nonneg),
+        mul_comm _ ((∂ν/∂_ ∘ₘ _) _).toReal, ← smul_eq_mul, setIntegral_rnDeriv_smul hνac hs.compl]
+      simp
+    _ = ∫ x in sᶜ, (max 0 ((π {true}).toReal - (π {false} * (∂μ/∂ν) x).toReal)) ∂ν := by
+      apply setIntegral_congr_ae hs.compl
+      filter_upwards [Measure.rnDeriv_restrict μ ν hs.compl] with x hx1 hxs
+      rw [hx1, indicator_of_mem hxs]
+    _ = ∫ x, (max 0 ((π {true}).toReal - (π {false} * (∂μ/∂ν) x).toReal)) ∂ν := by
+      simp_rw [ENNReal.toReal_mul]
+      nth_rw 2 [← integral_add_compl hs]
+      swap
+      · exact (integrable_zero _ _ _).sup
+          ((integrable_const _).sub (Measure.integrable_toReal_rnDeriv.const_mul _))
+      rw [setIntegral_zero_measure _ (Measure.measure_singularPartSet μ ν), zero_add]
+
+
+lemma statInfo_eq_lintegral_max_of_le (μ ν : Measure 𝒳) [IsFiniteMeasure μ] [IsFiniteMeasure ν]
+    (π : Measure Bool) [IsFiniteMeasure π] (h : π {false} * μ univ ≤ π {true} * ν univ) :
+    statInfo μ ν π
+      = ∫⁻ x, max 0 (π {false} * (∂μ/∂ν) x - π {true}) ∂ν + π {false} * μ.singularPart ν univ := by
+  sorry
+
+lemma statInfo_eq_lintegral_max_of_gt (μ ν : Measure 𝒳) [IsFiniteMeasure μ] [IsFiniteMeasure ν]
+    (π : Measure Bool) [IsFiniteMeasure π] (h : π {true} * ν univ < π {false} * μ univ) :
+    statInfo μ ν π = ∫⁻ x, max 0 (π {true} - π {false} * (∂μ/∂ν) x) ∂ν := by
+  sorry
+
 section StatInfoFun
 
 open Set Filter ConvexOn

--- a/TestingLowerBounds/ForMathlib/ByParts.lean
+++ b/TestingLowerBounds/ForMathlib/ByParts.lean
@@ -2,7 +2,7 @@ import Mathlib.MeasureTheory.Integral.IntervalIntegral
 
 /-!
 Here there is the statement of a version of the integration by parts theorem for the Riemann-Stieltjes integral.
-This is a generalization of the integration by parts theorem for the Riemann integral. We state it only for the case of Stieltjes functions, that is right continuous and non decreasing, this is because in that case the functions naturally gives rise to a measure. It maybe generalized to the more general case with signed measures, but it is necessary to pinpoint the right conditions for that case and it may be necessary to write the definition of the signed measure that arises from a function (I don't know the exact hp for the function, maybe bounded variation?)
+This is a generalization of the integration by parts theorem for the Riemann integral. We state it only for the case of Stieltjes functions, that is right continuous and non decreasing, this is because in that case the functions naturally gives rise to a measure. It may be generalized to the more general case with signed measures, but it is necessary to pinpoint the right conditions for that case and it may be necessary to write the definition of the signed measure that arises from a function (I don't know the exact hp for the function, maybe bounded variation?).
 For now I am only stating the theorem and I'm leaving the proof for later.
 Some references for potential candidates for the proof are:
 http://mathonline.wikidot.com/the-formula-for-integration-by-parts-of-riemann-stieltjes-in
@@ -10,12 +10,11 @@ Mathematical analysis, Tom M. Apostol, 5th edition theorem 7.6, page 144 (seems 
 The integrals of Lebesgue, Denjoy, Perron, and Henstock, theorem 12.14
 
 See also https://math.ryerson.ca/~niushan/Stieltjes-integrals.pdf for some facts about Riemann-Stieltjes and Lebesgue integrals.
-Here I am stating the results in terms of Lebesgue integrals, since it is what I need and the RS integral is equal to the Lebesgue one if one of the functions is increasing and right continuous and the other is bounded and measurable (see 4.1 in the previous link).
-To prove the general result it may be better to develop a theory of the Riemann-Stieltjes integral in mathlib adn then prove the results for that integral and translate them for the lebesgue integral when possible.
+Here I am stating the results in terms of interval integrals, since it is what I need and the RS integral is equal to the Lebesgue one if one of the functions is increasing and right continuous and the other is bounded and measurable (see 4.1 in the previous link).
+To prove the general result it may be better to develop a theory of the Riemann-Stieltjes integral in mathlib and then prove the results for that integral and translate them for the lebesgue integral when possible.
 -/
--- #check intervalIntegral.integral_deriv_mul_eq_sub_of_hasDeriv_right --one of the versions of the integratio by parts that is currently in mathlib
+-- #check intervalIntegral.integral_deriv_mul_eq_sub_of_hasDeriv_right --one of the versions of the integration by parts that is currently in mathlib.
 
 lemma integral_stieltjes_meas_by_parts (f g : StieltjesFunction) (a b : ℝ) :
     ∫ x in a..b, f x ∂g.measure = (f b) * (g b) - (f a) * (g a) - ∫ x in a..b, g x ∂f.measure := by
   sorry
---maybe post this on Zulip?

--- a/TestingLowerBounds/ForMathlib/SetIntegral.lean
+++ b/TestingLowerBounds/ForMathlib/SetIntegral.lean
@@ -1,0 +1,30 @@
+import Mathlib.MeasureTheory.Decomposition.RadonNikodym
+
+namespace MeasureTheory
+open scoped ENNReal
+
+variable {α E : Type*} [MeasurableSpace α] {μ ν : Measure α} [NormedAddCommGroup E] [NormedSpace ℝ E]
+
+-- PR this, just after `integral_rnDeriv_smul`
+lemma setIntegral_rnDeriv_smul [Measure.HaveLebesgueDecomposition μ ν] (hμν : μ ≪ ν)
+    [SigmaFinite μ] {f : α → E} {s : Set α} (hs : MeasurableSet s) :
+    ∫ x in s, (μ.rnDeriv ν x).toReal • f x ∂ν = ∫ x in s, f x ∂μ := by
+  simp_rw [← integral_indicator hs, Set.indicator_smul, integral_rnDeriv_smul hμν]
+
+-- PR this, just after `integral_zero_measure`
+@[simp]
+theorem setIntegral_zero_measure
+    (f : α → E) {μ : Measure α} {s : Set α} (hs : μ s = 0) :
+    ∫ x in s, f x ∂μ = 0 := Measure.restrict_eq_zero.mpr hs ▸ integral_zero_measure f
+
+--PR these two lemmas to mathlib, just under `lintegral_eq_zero_iff`
+theorem setLIntegral_eq_zero_iff' {s : Set α} (hs : MeasurableSet s)
+    {f : α → ℝ≥0∞} (hf : AEMeasurable f (μ.restrict s)) :
+    ∫⁻ a in s, f a ∂μ = 0 ↔ ∀ᵐ x ∂μ, x ∈ s → f x = 0 :=
+  (lintegral_eq_zero_iff' hf).trans (ae_restrict_iff' hs)
+
+theorem setLIntegral_eq_zero_iff {s : Set α} (hs : MeasurableSet s) {f : α → ℝ≥0∞}
+    (hf : Measurable f) : ∫⁻ a in s, f a ∂μ = 0 ↔ ∀ᵐ x ∂μ, x ∈ s → f x = 0 :=
+  setLIntegral_eq_zero_iff' hs hf.aemeasurable
+
+end MeasureTheory

--- a/TestingLowerBounds/Testing/Binary.lean
+++ b/TestingLowerBounds/Testing/Binary.lean
@@ -576,11 +576,10 @@ lemma toReal_bayesBinaryRisk_eq_integral_min (μ ν : Measure 𝒳) [IsFiniteMea
 lemma toReal_bayesBinaryRisk_eq_integral_abs (μ ν : Measure 𝒳) [IsFiniteMeasure μ]
     [IsFiniteMeasure ν] (π : Measure Bool) [IsFiniteMeasure π] :
     (bayesBinaryRisk μ ν π).toReal
-      = (2 : ℝ)⁻¹ * (((twoHypKernel μ ν ∘ₘ π) Set.univ).toReal
+      = 2⁻¹ * (((twoHypKernel μ ν ∘ₘ π) Set.univ).toReal
         - ∫ x, |(π {false} * μ.rnDeriv (twoHypKernel μ ν ∘ₘ π) x).toReal
           - (π {true} * ν.rnDeriv (twoHypKernel μ ν ∘ₘ π) x).toReal| ∂(twoHypKernel μ ν ∘ₘ π)) := by
-  rw [toReal_bayesBinaryRisk_eq_integral_min]
-  simp_rw [min_eq_add_sub_abs_sub, integral_mul_left]
+  simp_rw [toReal_bayesBinaryRisk_eq_integral_min, min_eq_add_sub_abs_sub, integral_mul_left]
   congr
   have hμ_int : Integrable (fun x ↦ (π {false} * μ.rnDeriv (twoHypKernel μ ν ∘ₘ π) x).toReal)
       (twoHypKernel μ ν ∘ₘ π) := by

--- a/blueprint/src/sections/stat_div.tex
+++ b/blueprint/src/sections/stat_div.tex
@@ -22,13 +22,13 @@ This is a simple generalization of both the DeGroot statistical information as w
 
 \begin{lemma}
   \label{lem:statInfo_self}
-  %\lean{}
-  %\leanok
+  \lean{ProbabilityTheory.statInfo_self}
+  \leanok
   \uses{def:statInfo}
   For $\mu \in \mathcal M(\mathcal X)$, $\mathcal I_\xi(\mu, \mu) = 0$~.
 \end{lemma}
 
-\begin{proof}%\leanok
+\begin{proof}\leanok
 \uses{lem:bayesBinaryRisk_self}
 Use Lemma~\ref{lem:bayesBinaryRisk_self}.
 \end{proof}
@@ -49,13 +49,13 @@ Use Lemma~\ref{lem:bayesBinaryRisk_le}.
 
 \begin{lemma}
   \label{lem:statInfo_le}
-  %\lean{}
-  %\leanok
+  \lean{ProbabilityTheory.statInfo_le_min}
+  \leanok
   \uses{def:statInfo}
   For $\mu, \nu \in \mathcal M(\mathcal X)$, $\mathcal I_\xi(\mu, \nu) \le \min\{\xi_0 \mu(\mathcal X), \xi_1 \nu(\mathcal X)\}$~.
 \end{lemma}
 
-\begin{proof}%\leanok
+\begin{proof}\leanok
 \uses{lem:bayesBinaryRisk_nonneg}
 Use Lemma~\ref{lem:bayesBinaryRisk_nonneg}.
 \end{proof}
@@ -63,13 +63,13 @@ Use Lemma~\ref{lem:bayesBinaryRisk_nonneg}.
 
 \begin{lemma}
   \label{lem:statInfo_symm}
-  %\lean{}
-  %\leanok
+  \lean{ProbabilityTheory.statInfo_symm}
+  \leanok
   \uses{def:statInfo}
   For $\mu, \nu \in \mathcal M(\mathcal X)$ and $\xi \in \mathcal M(\{0,1\})$, $\mathcal I_\xi(\mu, \nu) = \mathcal I_{\xi_\leftrightarrow}(\nu, \mu)$~.
 \end{lemma}
 
-\begin{proof}%\leanok
+\begin{proof}\leanok
 \uses{lem:bayesBinaryRisk_symm}
 Use Lemma~\ref{lem:bayesBinaryRisk_symm}.
 \end{proof}
@@ -100,14 +100,14 @@ Alternatively, we can use Lemma~\ref{lem:riskIncrease_comp_del}.
 
 \begin{corollary}
   \label{cor:statInfo_data_proc_event}
-  %\lean{}
-  %\leanok
+  \lean{ProbabilityTheory.statInfo_boolMeasure_le_statInfo}
+  \leanok
   \uses{def:statInfo}
   Let $\mu, \nu$ be two measures on $\mathcal X$, $\xi \in \mathcal M(\{0,1\})$ and let $E$ be an event on $\mathcal X$. Let $\mu_E$ and $\nu_E$ be the two Bernoulli distributions with respective means $\mu(E)$ and $\nu(E)$.
   Then $\mathcal I_\xi(\mu, \nu) \ge \mathcal I_\xi(\mu_E, \nu_E)$.
 \end{corollary}
 
-\begin{proof}
+\begin{proof}\leanok
 \uses{thm:data_proc_statInfo}
 Apply Theorem~\ref{thm:data_proc_statInfo} to the deterministic kernel $\mathcal X \rightsquigarrow \{0,1\}$ given by the function $x \mapsto \mathbb{I}\{x \in E\}$.
 \end{proof}
@@ -115,8 +115,8 @@ Apply Theorem~\ref{thm:data_proc_statInfo} to the deterministic kernel $\mathcal
 
 \begin{lemma}
   \label{lem:statInfo_eq_sub_min}
-  %\lean{}
-  %\leanok
+  \lean{ProbabilityTheory.statInfo_eq_min_sub_lintegral, ProbabilityTheory.statInfo_eq_min_sub_lintegral', ProbabilityTheory.toReal_statInfo_eq_min_sub_integral}
+  \leanok
   \uses{def:statInfo}
   For finite measures $\mu, \nu$ and $\xi \in \mathcal M(\{0,1\})$, for any measure $\zeta$ with $\mu \ll \zeta$ and $\nu \ll \zeta$~,
   \begin{align*}
@@ -127,7 +127,7 @@ Apply Theorem~\ref{thm:data_proc_statInfo} to the deterministic kernel $\mathcal
   This holds in particular for $\zeta = P \circ \xi$.
 \end{lemma}
 
-\begin{proof}%\leanok
+\begin{proof}\leanok
 \uses{thm:bayesBinaryRisk_eq}
 Apply Theorem~\ref{thm:bayesBinaryRisk_eq} to get that result for $\zeta = P \circ \xi$. Then for other $\zeta$ with $\mu \ll \zeta$ and $\nu \ll \zeta$~, use $\frac{d \mu}{d\zeta} = \frac{d \mu}{d(P \circ \xi)} / \frac{d (P \circ \xi)}{d\zeta}$~.
 \end{proof}
@@ -135,8 +135,8 @@ Apply Theorem~\ref{thm:bayesBinaryRisk_eq} to get that result for $\zeta = P \ci
 
 \begin{lemma}
   \label{lem:statInfo_eq_integral_abs_sub}
-  %\lean{}
-  %\leanok
+  \lean{ProbabilityTheory.statInfo_eq_abs_add_lintegral_abs}
+  \leanok
   \uses{def:statInfo}
   For finite measures $\mu, \nu$ and $\xi \in \mathcal M(\{0,1\})$, for any measure $\zeta$ with $\mu \ll \zeta$ and $\nu \ll \zeta$~,
   \begin{align*}
@@ -157,8 +157,8 @@ The result for other $\zeta$ follows from simple manipulations of Radon-Nikodym 
 
 \begin{theorem}[Integral form of the statistical information]
   \label{thm:statInfo_eq_integral}
-  %\lean{}
-  %\leanok
+  \lean{ProbabilityTheory.toReal_statInfo_eq_integral_max_of_le, ProbabilityTheory.toReal_statInfo_eq_integral_max_of_gt}
+  \leanok
   \uses{def:statInfo}
   For finite measures $\mu, \nu$ and $\xi \in \mathcal M(\{0,1\})$,
   \begin{align*}
@@ -174,7 +174,7 @@ The result for other $\zeta$ follows from simple manipulations of Radon-Nikodym 
 
 For probability measures, this theorem makes the statistical information an $f$-divergence (which is defined later in this document).
 
-\begin{proof}%\leanok
+\begin{proof}\leanok
 \uses{thm:bayesBinaryRisk_eq}
 By Theorem~\ref{thm:bayesBinaryRisk_eq},
 \begin{align*}


### PR DESCRIPTION
- Add statement and partial proof of `toReal_statInfo_eq_min_sub_integral'` and `statInfo_eq_abs_add_lintegral_abs` (they are not used in the next proofs.
- Add `toReal_statInfo_eq_integral_max_of_le` and `toReal_statInfo_eq_integral_max_of_gt` (integral form representation of `StatInfo`).
- Add statements of `statInfo_eq_lintegral_max_of_le` and `statInfo_eq_lintegral_max_of_gt`.
- Add lemmas about the `rnDeriv`: `rnDeriv_eq_zero_ae_of_zero_measure`, `rnDeriv_eq_zero_ae_of_singularPartSet` and `rnDeriv_mul_rnDeriv'`.
- Add lemmas about `SetIntegral` and `SetLIntegral`: `setIntegral_rnDeriv_smul`, `setIntegral_zero_measure`,  `setLIntegral_eq_zero_iff'`, `setLIntegral_eq_zero_iff`.
- Update blueprint.
- Cleanup.