### PR TITLE
Golf and small changes

### DIFF
--- a/TestingLowerBounds/Divergences/Renyi.lean
+++ b/TestingLowerBounds/Divergences/Renyi.lean
@@ -524,8 +524,7 @@ lemma le_renyiDiv_of_le_hellingerDiv {a : ℝ} {μ₁ ν₁ : Measure α} {μ₂
   · simp_rw [renyiDiv_of_ne_one ha.ne', h_eq]
     gcongr
     · simp only [EReal.coe_nonneg, inv_nonneg, sub_nonneg, ha.le]
-    refine ENNReal.log_monotone ?_
-    apply EReal.toENNReal_le_toENNReal
+    refine ENNReal.log_monotone <| EReal.toENNReal_le_toENNReal ?_
     gcongr
     norm_cast
     linarith
@@ -533,10 +532,9 @@ lemma le_renyiDiv_of_le_hellingerDiv {a : ℝ} {μ₁ ν₁ : Measure α} {μ₂
 lemma le_renyiDiv_compProd [CountableOrCountablyGenerated α β] (ha_pos : 0 < a)
     (μ ν : Measure α) [IsFiniteMeasure μ] [IsFiniteMeasure ν]
     (κ η : Kernel α β) [IsMarkovKernel κ] [IsMarkovKernel η] :
-    renyiDiv a μ ν ≤ renyiDiv a (μ ⊗ₘ κ) (ν ⊗ₘ η) := by
-  refine le_renyiDiv_of_le_hellingerDiv ?_ (le_hellingerDiv_compProd ha_pos μ ν κ η)
-  rw [Measure.compProd_apply .univ]
-  simp
+    renyiDiv a μ ν ≤ renyiDiv a (μ ⊗ₘ κ) (ν ⊗ₘ η) :=
+  le_renyiDiv_of_le_hellingerDiv Measure.compProd_apply_univ.symm
+    (le_hellingerDiv_compProd ha_pos μ ν κ η)
 
 lemma renyiDiv_fst_le [Nonempty β] [StandardBorelSpace β] (ha_pos : 0 < a)
     (μ ν : Measure (α × β)) [IsFiniteMeasure μ] [IsFiniteMeasure ν] :
@@ -567,10 +565,8 @@ lemma renyiDiv_comp_right_le [Nonempty α] [StandardBorelSpace α] (ha_pos : 0 <
     [CountableOrCountablyGenerated α β]
     (μ ν : Measure α) [IsFiniteMeasure μ] [IsFiniteMeasure ν]
     (κ : Kernel α β) [IsMarkovKernel κ] :
-    renyiDiv a (κ ∘ₘ μ) (κ ∘ₘ ν) ≤ renyiDiv a μ ν := by
-  refine le_renyiDiv_of_le_hellingerDiv ?_ (hellingerDiv_comp_right_le ha_pos μ ν κ)
-  rw [← Measure.snd_compProd ν κ, Measure.snd_univ, Measure.compProd_apply .univ]
-  simp
+    renyiDiv a (κ ∘ₘ μ) (κ ∘ₘ ν) ≤ renyiDiv a μ ν :=
+  le_renyiDiv_of_le_hellingerDiv Measure.comp_apply_univ (hellingerDiv_comp_right_le ha_pos μ ν κ)
 
 end DataProcessingInequality
 

--- a/TestingLowerBounds/Divergences/fDivStatInfo.lean
+++ b/TestingLowerBounds/Divergences/fDivStatInfo.lean
@@ -335,10 +335,11 @@ lemma fDiv_ne_top_iff_integrable_fDiv_statInfoFun_of_absolutelyContinuous
     curvatureMeasure_add_const, curvatureMeasure_add_linear, curvatureMeasure_add_const]
   · exact (hf_cvx.add_const _).add (const_mul_id (-rightDeriv f 1)) |>.add_const _
   · exact ((hf_cont.add continuous_const).add (continuous_mul_left _)).add continuous_const
-  · have hf_diff x := differentiableWithinAt_Ioi hf_cvx x
-    rw [rightDeriv_add_const (by fun_prop), rightDeriv_add_linear (by fun_prop),
-      rightDeriv_add_const hf_diff]
-    simp
+  · have hf_diff := differentiableWithinAt_Ioi'
+      (hf_cvx.subset (fun _ _ ↦ trivial) (convex_Ici 0)) zero_lt_one
+    rw [rightDeriv_add_const_apply, rightDeriv_add_linear_apply, rightDeriv_add_const_apply hf_diff,
+      add_neg_cancel] <;> fun_prop
+
 
 lemma integrable_f_rnDeriv_iff_integrable_fDiv_statInfoFun_of_absolutelyContinuous
     [IsFiniteMeasure μ] [IsFiniteMeasure ν]
@@ -399,18 +400,18 @@ lemma fDiv_eq_integral_fDiv_statInfoFun_of_absolutelyContinuous
       + f 1 * ν univ + rightDeriv f 1 * (μ univ - ν univ) := by
   rw [fDiv_eq_fDiv_centeredFunction (hf_cvx.subset (fun _ _ ↦ trivial) (convex_Ici 0))]
   congr
-  · have h : ConvexOn ℝ univ (fun x ↦ f x - f 1 - rightDeriv f 1 * (x - 1)) := by
-      simp_rw [mul_sub, sub_eq_add_neg, neg_add, neg_neg, ← neg_mul]
-      exact (hf_cvx.add_const _).add ((ConvexOn.const_mul_id _).add (convexOn_const _ convex_univ))
-    rw [fDiv_eq_integral_fDiv_statInfoFun_of_absolutelyContinuous'
-      h (by continuity) (by simp) _ _ h_ac]
+  · rw [fDiv_eq_integral_fDiv_statInfoFun_of_absolutelyContinuous'
+      _ (by continuity) (by simp) _ _ h_ac]
     · simp_rw [mul_sub, sub_eq_add_neg, neg_add, neg_neg, ← neg_mul, ← add_assoc,
         curvatureMeasure_add_const, curvatureMeasure_add_linear, curvatureMeasure_add_const]
-    · have hf_diff x := differentiableWithinAt_Ioi hf_cvx x
+    · simp_rw [mul_sub, sub_eq_add_neg, neg_add, neg_neg, ← neg_mul]
+      exact (hf_cvx.add_const _).add ((ConvexOn.const_mul_id _).add (convexOn_const _ convex_univ))
+    · have hf_diff := differentiableWithinAt_Ioi'
+        (hf_cvx.subset (fun _ _ ↦ trivial) (convex_Ici 0)) zero_lt_one
       simp_rw [mul_sub, sub_eq_add_neg, neg_add, neg_neg, ← neg_mul, ← add_assoc]
-      rw [rightDeriv_add_const (by fun_prop), rightDeriv_add_linear (by fun_prop),
-        rightDeriv_add_const hf_diff]
-      simp
+      rw [rightDeriv_add_const_apply, rightDeriv_add_linear_apply,
+        rightDeriv_add_const_apply hf_diff, add_neg_cancel]
+      <;> fun_prop
     · exact (h_int.sub (integrable_const _)).sub
         ((Measure.integrable_toReal_rnDeriv.sub (integrable_const 1)).const_mul _)
   all_goals exact ENNReal.toReal_toEReal_of_ne_top (measure_ne_top _ _)
@@ -623,13 +624,24 @@ lemma fDiv_comp_right_le' [IsFiniteMeasure μ] [IsFiniteMeasure ν]
   exact lintegral_mono fun x ↦ EReal.toENNReal_le_toENNReal <|
     fDiv_statInfoFun_comp_right_le η zero_le_one
 
+lemma fDiv_fst_le' (μ ν : Measure (𝒳 × 𝒳')) [IsFiniteMeasure μ] [IsFiniteMeasure ν]
+    (hf_cvx : ConvexOn ℝ univ f) (hf_cont : Continuous f) :
+    fDiv f μ.fst ν.fst ≤ fDiv f μ ν := by
+  simp_rw [Measure.fst, ← Measure.comp_deterministic_eq_map measurable_fst]
+  exact fDiv_comp_right_le' _ hf_cvx hf_cont
+
+lemma fDiv_snd_le' (μ ν : Measure (𝒳 × 𝒳')) [IsFiniteMeasure μ] [IsFiniteMeasure ν]
+    (hf_cvx : ConvexOn ℝ univ f) (hf_cont : Continuous f) :
+    fDiv f μ.snd ν.snd ≤ fDiv f μ ν := by
+  simp_rw [Measure.snd, ← Measure.comp_deterministic_eq_map measurable_snd]
+  exact fDiv_comp_right_le' _ hf_cvx hf_cont
+
 lemma le_fDiv_compProd' [IsFiniteMeasure μ] [IsFiniteMeasure ν]
     (κ η : Kernel 𝒳 𝒳') [IsMarkovKernel κ] [IsMarkovKernel η] (hf_cvx : ConvexOn ℝ univ f)
     (hf_cont : Continuous f) :
     fDiv f μ ν ≤ fDiv f (μ ⊗ₘ κ) (ν ⊗ₘ η) := by
   nth_rw 1 [← Measure.fst_compProd μ κ, ← Measure.fst_compProd ν η]
-  simp_rw [Measure.fst, ← Measure.comp_deterministic_eq_map measurable_fst]
-  exact fDiv_comp_right_le' _ hf_cvx hf_cont
+  exact fDiv_fst_le' _ _ hf_cvx hf_cont
 
 lemma fDiv_compProd_right' [IsFiniteMeasure μ] [IsFiniteMeasure ν]
     (κ : Kernel 𝒳 𝒳') [IsMarkovKernel κ] (hf_cvx : ConvexOn ℝ univ f) (hf_cont : Continuous f) :
@@ -643,26 +655,13 @@ lemma fDiv_comp_le_compProd' [IsFiniteMeasure μ] [IsFiniteMeasure ν]
     (hf_cont : Continuous f) :
     fDiv f (κ ∘ₘ μ) (η ∘ₘ ν) ≤ fDiv f (μ ⊗ₘ κ) (ν ⊗ₘ η) := by
   nth_rw 1 [← Measure.snd_compProd μ κ, ← Measure.snd_compProd ν η]
-  simp_rw [Measure.snd, ← Measure.comp_deterministic_eq_map measurable_snd]
-  exact fDiv_comp_right_le' _ hf_cvx hf_cont
+  exact fDiv_snd_le' _ _ hf_cvx hf_cont
 
 lemma fDiv_comp_le_compProd_right' [IsFiniteMeasure μ]
     (κ η : Kernel 𝒳 𝒳') [IsMarkovKernel κ] [IsMarkovKernel η] (hf_cvx : ConvexOn ℝ univ f)
     (hf_cont : Continuous f) :
     fDiv f (κ ∘ₘ μ) (η ∘ₘ μ) ≤ fDiv f (μ ⊗ₘ κ) (μ ⊗ₘ η) :=
   fDiv_comp_le_compProd' κ η hf_cvx hf_cont
-
-lemma fDiv_fst_le' (μ ν : Measure (𝒳 × 𝒳')) [IsFiniteMeasure μ] [IsFiniteMeasure ν]
-    (hf_cvx : ConvexOn ℝ univ f) (hf_cont : Continuous f) :
-    fDiv f μ.fst ν.fst ≤ fDiv f μ ν := by
-  simp_rw [Measure.fst, ← Measure.comp_deterministic_eq_map measurable_fst]
-  exact fDiv_comp_right_le' _ hf_cvx hf_cont
-
-lemma fDiv_snd_le' (μ ν : Measure (𝒳 × 𝒳')) [IsFiniteMeasure μ] [IsFiniteMeasure ν]
-    (hf_cvx : ConvexOn ℝ univ f) (hf_cont : Continuous f) :
-    fDiv f μ.snd ν.snd ≤ fDiv f μ ν := by
-  simp_rw [Measure.snd, ← Measure.comp_deterministic_eq_map measurable_snd]
-  exact fDiv_comp_right_le' _ hf_cvx hf_cont
 
 end DataProcessingInequality
 

--- a/TestingLowerBounds/FDiv/Basic.lean
+++ b/TestingLowerBounds/FDiv/Basic.lean
@@ -809,20 +809,15 @@ lemma fDiv_map_measurableEmbedding [IsFiniteMeasure μ] [IsFiniteMeasure ν]
     swap
     · rw [hg.integrable_map_iff]
       refine (integrable_congr ?_).mpr h_int
-      filter_upwards [hg.rnDeriv_map μ ν] with a ha
-      simp [ha]
+      filter_upwards [hg.rnDeriv_map μ ν] with a ha using ha ▸ rfl
     rw [hg.integral_map]
     congr 2
     · refine integral_congr_ae ?_
-      filter_upwards [hg.rnDeriv_map μ ν] with a ha
-      simp [ha]
-    · rw [hg.singularPart_map μ ν, hg.map_apply]
-      simp
+      filter_upwards [hg.rnDeriv_map μ ν] with a ha using ha ▸ rfl
+    · rw [hg.singularPart_map μ ν, hg.map_apply, preimage_univ]
   · rw [fDiv_of_not_integrable h_int, fDiv_of_not_integrable]
-    rw [hg.integrable_map_iff]
-    rwa [(integrable_congr ?_)]
-    filter_upwards [hg.rnDeriv_map μ ν] with a ha
-    simp [ha]
+    rwa [hg.integrable_map_iff, integrable_congr ?_]
+    filter_upwards [hg.rnDeriv_map μ ν] with a ha using ha ▸ rfl
 
 lemma fDiv_restrict_of_integrable (μ ν : Measure α) [IsFiniteMeasure μ] [IsFiniteMeasure ν]
     {s : Set α} (hs : MeasurableSet s) (h_int : IntegrableOn (fun x ↦ f ((∂μ/∂ν) x).toReal) s ν) :

--- a/TestingLowerBounds/ForMathlib/LeftRightDeriv.lean
+++ b/TestingLowerBounds/ForMathlib/LeftRightDeriv.lean
@@ -209,6 +209,11 @@ lemma leftDeriv_add_apply {f g : ℝ → ℝ} {x : ℝ} (hf : DifferentiableWith
   simp_rw [leftDeriv_def, ← derivWithin_add (uniqueDiffWithinAt_Iio x) hf hg]
   rfl
 
+lemma leftDeriv_add_apply' {f g : ℝ → ℝ} {x : ℝ} (hf : DifferentiableWithinAt ℝ f (Iio x) x)
+    (hg : DifferentiableWithinAt ℝ g (Iio x) x) :
+    leftDeriv (fun x ↦ f x + g x) x = leftDeriv f x + leftDeriv g x :=
+  leftDeriv_add_apply hf hg
+
 lemma leftDeriv_add {f g : ℝ → ℝ} (hf : ∀ x, DifferentiableWithinAt ℝ f (Iio x) x)
     (hg : ∀ x, DifferentiableWithinAt ℝ g (Iio x) x) :
     leftDeriv (f + g) = fun x ↦ leftDeriv f x + leftDeriv g x := by
@@ -219,23 +224,45 @@ lemma leftDeriv_add' {f g : ℝ → ℝ} (hf : ∀ x, DifferentiableWithinAt ℝ
     leftDeriv (fun x ↦ f x + g x) = fun x ↦ leftDeriv f x + leftDeriv g x := by
   simp_rw [← Pi.add_apply f g, leftDeriv_add hf hg]
 
+lemma rightDeriv_add_const_apply {f : ℝ → ℝ} {x : ℝ} (hf : DifferentiableWithinAt ℝ f (Ioi x) x)
+    (c : ℝ) :
+    rightDeriv (fun x ↦ f x + c) x = rightDeriv f x := by
+  rw [rightDeriv_add_apply' hf (differentiableWithinAt_const c), rightDeriv_const,
+    Pi.zero_apply, add_zero]
+
 lemma rightDeriv_add_const {f : ℝ → ℝ} (hf : ∀ x, DifferentiableWithinAt ℝ f (Ioi x) x) (c : ℝ) :
     rightDeriv (fun x ↦ f x + c) = rightDeriv f := by
-  simp [rightDeriv_add' hf (fun _ ↦ differentiableWithinAt_const c)]
+  ext x; exact rightDeriv_add_const_apply (hf x) c
+
+lemma leftDeriv_add_const_apply {f : ℝ → ℝ} {x : ℝ} (hf : DifferentiableWithinAt ℝ f (Iio x) x)
+    (c : ℝ) :
+    leftDeriv (fun x ↦ f x + c) x = leftDeriv f x := by
+  rw [leftDeriv_add_apply' hf (differentiableWithinAt_const c), leftDeriv_const,
+    Pi.zero_apply, add_zero]
 
 lemma leftDeriv_add_const {f : ℝ → ℝ} (hf : ∀ x, DifferentiableWithinAt ℝ f (Iio x) x) (c : ℝ) :
     leftDeriv (fun x ↦ f x + c) = leftDeriv f := by
-  simp [leftDeriv_add' hf (fun _ ↦ differentiableWithinAt_const c)]
+  ext x; exact leftDeriv_add_const_apply (hf x) c
+
+lemma rightDeriv_add_linear_apply {f : ℝ → ℝ} {x : ℝ} (hf : DifferentiableWithinAt ℝ f (Ioi x) x)
+    (a : ℝ) :
+    rightDeriv (fun x ↦ f x + a * x) x = rightDeriv f x + a := by
+  rw [rightDeriv_add_apply' hf (by fun_prop), rightDeriv_const_mul, rightDeriv_id']
+  simp
 
 lemma rightDeriv_add_linear {f : ℝ → ℝ} (hf : ∀ x, DifferentiableWithinAt ℝ f (Ioi x) x) (a : ℝ) :
     rightDeriv (fun x ↦ f x + a * x) = rightDeriv f + fun _ ↦ a := by
-  rw [rightDeriv_add' hf (by fun_prop), rightDeriv_const_mul, rightDeriv_id']
-  ext; simp
+  ext x; exact rightDeriv_add_linear_apply (hf x) a
+
+lemma leftDeriv_add_linear_apply {f : ℝ → ℝ} {x : ℝ} (hf : DifferentiableWithinAt ℝ f (Iio x) x)
+    (a : ℝ) :
+    leftDeriv (fun x ↦ f x + a * x) x = leftDeriv f x + a := by
+  rw [leftDeriv_add_apply' hf (by fun_prop), leftDeriv_const_mul, leftDeriv_id']
+  simp
 
 lemma leftDeriv_add_linear {f : ℝ → ℝ} (hf : ∀ x, DifferentiableWithinAt ℝ f (Iio x) x) (a : ℝ) :
     leftDeriv (fun x ↦ f x + a * x) = leftDeriv f + fun _ ↦ a := by
-  rw [leftDeriv_add' hf (by fun_prop), leftDeriv_const_mul, leftDeriv_id']
-  ext; simp
+  ext x; exact leftDeriv_add_linear_apply (hf x) a
 
 
 namespace ConvexOn

--- a/TestingLowerBounds/Testing/Risk.lean
+++ b/TestingLowerBounds/Testing/Risk.lean
@@ -41,8 +41,8 @@ an objective function `y` on the parameter space and a cost function `ℓ`.
 We don't put the data generating kernel into this structure, since we will often perform operations
 on it and we don't want to duplicate all kernel operations on `estimationProblem`. -/
 @[ext]
-structure estimationProblem (Θ 𝒴 𝒵 : Type*) [mΘ : MeasurableSpace Θ]
-    [m𝒴 : MeasurableSpace 𝒴] [m𝒵 : MeasurableSpace 𝒵] :=
+structure estimationProblem (Θ 𝒴 𝒵 : Type*) [MeasurableSpace Θ]
+    [MeasurableSpace 𝒴] [MeasurableSpace 𝒵] :=
   /-- The objective function. -/
   y : Θ → 𝒴
   y_meas : Measurable y

--- a/TestingLowerBounds/Testing/TwoHypKernel.lean
+++ b/TestingLowerBounds/Testing/TwoHypKernel.lean
@@ -240,7 +240,8 @@ lemma bayesInv_twoHypKernel (μ ν : Measure 𝒳) [IsFiniteMeasure μ] [IsFinit
     rw [Measure.bind_apply hA (by exact fun _ _ ↦ hB), Bool.lintegral_bool]
     simp
 
-lemma bayesRiskPrior_eq_of_hasGenBayesEstimator_binary (E : estimationProblem Bool Bool Bool)
+lemma bayesRiskPrior_eq_of_hasGenBayesEstimator_binary {𝒴 𝒵 : Type*}
+    [MeasurableSpace 𝒴] [MeasurableSpace 𝒵] (E : estimationProblem Bool 𝒴 𝒵)
     (P : Kernel Bool 𝒳) [IsFiniteKernel P] (π : Measure Bool) [IsFiniteMeasure π]
     [h : HasGenBayesEstimator E P π] :
     bayesRiskPrior E P π
@@ -250,8 +251,7 @@ lemma bayesRiskPrior_eq_of_hasGenBayesEstimator_binary (E : estimationProblem Bo
   have h1 := bayesInv_twoHypKernel (P false) (P true) π
   have h2 : P = twoHypKernel (P false) (P true) := Kernel_bool_eq_twoHypKernel P
   have h3 : (P†π) = twoHypKernel (P false) (P true)†π := by congr
-  nth_rw 1 [h2]
-  nth_rw 4 [h2]
+  nth_rw 1 3 [h2]
   simp_rw [h3]
   apply lintegral_congr_ae
   filter_upwards [h1, twoHypKernelInv_apply_false (P false) (P true) π,


### PR DESCRIPTION
- In fDivStatInfo, make the cases where convexity is needed only on `Ici 0` more explicit.
- Rearrange corollaries of the general DPI to golf proofs.
- Add some missing versions of lemmas for left and right deriv.
- Golf.
- Cleanup.